### PR TITLE
Modification du pattern des urls des posts

### DIFF
--- a/app/models/communication/website/permalink/post.rb
+++ b/app/models/communication/website/permalink/post.rb
@@ -7,10 +7,10 @@ class Communication::Website::Permalink::Post < Communication::Website::Permalin
     :posts
   end
 
-  # /actualites/2022/10/21/un-article/
+  # /actualites/2022-10-21/un-article/
   # Pas de /fr au début, parce qu'Hugo a besoin du permalink sans langue
   def self.pattern_in_website(website)
-    "#{website.special_page(:communication_posts).path_without_language}:year/:month/:day/:slug/"
+    "#{website.special_page(:communication_posts).path_without_language}:year-:month-:day-:slug/"
   end
 
   protected

--- a/app/views/admin/application/static/_permalink.html.erb
+++ b/app/views/admin/application/static/_permalink.html.erb
@@ -2,7 +2,6 @@ url: "<%= @about.current_permalink_in_website(@website)&.path %>"
 <% if @about.respond_to?(:slug) && @about.slug.present? %>
 slug: "<%= @about.slug %>"
 <% end %>
-<%# TODO: Understand why a "/" alias break some builds %>
 <%
 previous_permalinks = @about.previous_permalinks_in_website(@website).where.not(path: "/")
 if previous_permalinks.any?


### PR DESCRIPTION
Maintenant qu'on gère l'historique des urls des posts, on peut changer le pattern.
/:year/:month/:day/:slug -> /:year-:month-:day-:slug

Ce qui close l'issue https://github.com/noesya/osuny-hugo-theme-aaa/issues/33