### PR TITLE
Filtrer les attributs sensibles

### DIFF
--- a/app/models/communication/extranet.rb
+++ b/app/models/communication/extranet.rb
@@ -33,6 +33,8 @@
 #  fk_rails_c2268c7ebd  (university_id => universities.id)
 #
 class Communication::Extranet < ApplicationRecord
+  self.filter_attributes += [:sso_cert]
+
   include WithAbouts
   include WithLegal
   include WithSso

--- a/app/models/communication/website.rb
+++ b/app/models/communication/website.rb
@@ -30,6 +30,8 @@
 #  fk_rails_bb6a496c08  (university_id => universities.id)
 #
 class Communication::Website < ApplicationRecord
+  self.filter_attributes += [ :access_token ]
+
   include WithUniversity
   include WithAbouts
   include WithConfigs

--- a/app/models/university.rb
+++ b/app/models/university.rb
@@ -27,6 +27,8 @@
 #  updated_at                 :datetime         not null
 #
 class University < ApplicationRecord
+  self.filter_attributes += [:sso_cert]
+
   include WithPeopleAndOrganizations
   include WithCommunication
   include WithEducation


### PR DESCRIPTION
Eviter que certains attributs sensibles soient dévoilés dans les logs Ruby affichés dans les issues Bugsnag