### PR TITLE
Fix filtre catégorie

### DIFF
--- a/app/models/communication/website/post.rb
+++ b/app/models/communication/website/post.rb
@@ -83,10 +83,7 @@ class Communication::Website::Post < ApplicationRecord
   scope :ordered, -> { order(published_at: :desc, created_at: :desc) }
   scope :recent, -> { order(published_at: :desc).limit(5) }
   scope :for_author, -> (author_id) { where(author_id: author_id) }
-  scope :for_category, -> (category_id) {
-    descendant_ids = Communication::Website::Category.find_by(id: category_id)&.descendants&.map(&:id) || []
-    joins(:categories).where(communication_website_categories: { id: [category_id, descendant_ids].flatten }).distinct
-  }
+  scope :for_category, -> (category_id) { joins(:categories).where(communication_website_categories: { id: category_id }).distinct }
   scope :for_pinned, -> (pinned) { where(pinned: pinned == 'true') }
   scope :for_search_term, -> (term) {
     where("


### PR DESCRIPTION
Maintenant que les catégories ne gérent plus la parentelle automatiquement, quand on filtre par une catégorie, on affiche les posts liés à cette catégorie explicitement