### PR TITLE
Correction de la sync d'un nouveau fichier côté Osuny mais existant côté repo

### DIFF
--- a/app/services/git/providers/github.rb
+++ b/app/services/git/providers/github.rb
@@ -9,10 +9,12 @@ class Git::Providers::Github < Git::Providers::Abstract
   end
 
   def update_file(path, previous_path, content)
-    file = tree_item_at_path(previous_path)
+    # Handle newly created GitFiles which update existing remote files while having blank previous_path.
+    path_to_check = previous_path.present? ? previous_path : path
+    file = tree_item_at_path(path_to_check)
     return if file.nil?
     batch << {
-      path: previous_path,
+      path: path_to_check,
       mode: file[:mode],
       type: file[:type],
       sha: nil

--- a/app/services/git/providers/gitlab.rb
+++ b/app/services/git/providers/gitlab.rb
@@ -11,8 +11,7 @@ class Git::Providers::Gitlab < Git::Providers::Abstract
 
   def update_file(path, previous_path, content)
     file = find previous_path
-    return if file.nil?
-    if previous_path != path
+    if file.present? && previous_path != path
       batch << {
         action: 'move',
         file_path: path,


### PR DESCRIPTION
Quand on créait un nouvel objet sur un site (ex: config de langue), la méthode `update_file` faisait un early return si aucun fichier n'existait au previous path.

Or, il faut pouvoir update un objet quand le previous path est nil mais qu'un objet existe au nouveau path