### PR TITLE
Eviter la reconfirmation quand on change l'email d'un utilisateur depuis le BO

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -37,6 +37,7 @@ class Admin::UsersController < Admin::ApplicationController
 
   def update
     @user.modified_by = current_user
+    @user.skip_reconfirmation!
     manage_password
     if @user.update(user_params)
       redirect_to [:admin, @user], notice: t('admin.successfully_updated_html', model: @user.to_s)


### PR DESCRIPTION
close #588 