### PR TITLE
Pas de sync du numéro de téléphone + hints

### DIFF
--- a/app/models/user/with_person.rb
+++ b/app/models/user/with_person.rb
@@ -13,11 +13,10 @@ module User::WithPerson
   protected
 
   def find_or_create_person
-    person = university.people.where(email: email).first_or_initialize do |person|
-      person.first_name = first_name
-      person.last_name = last_name
-      person.slug = person.to_s.parameterize
-    end
+    person = university.people.where(email: email).first || university.people.new
+    person.first_name = first_name
+    person.last_name = last_name
+    person.slug = person.to_s.parameterize
     person.user = self
     person.save
   end
@@ -25,7 +24,6 @@ module User::WithPerson
   def sync_person
     person.first_name = first_name
     person.last_name = last_name
-    person.email = email
     person.slug = person.to_s.parameterize
     person.picture.purge if picture_infos.present? && person.picture&.attached?
     person.save

--- a/app/models/user/with_person.rb
+++ b/app/models/user/with_person.rb
@@ -17,7 +17,6 @@ module User::WithPerson
       person.first_name = first_name
       person.last_name = last_name
       person.slug = person.to_s.parameterize
-      person.phone_mobile = mobile_phone
     end
     person.user = self
     person.save
@@ -28,7 +27,6 @@ module User::WithPerson
     person.last_name = last_name
     person.email = email
     person.slug = person.to_s.parameterize
-    person.phone_mobile = mobile_phone
     person.picture.purge if picture_infos.present? && person.picture&.attached?
     person.save
   end

--- a/app/views/admin/university/people/_form.html.erb
+++ b/app/views/admin/university/people/_form.html.erb
@@ -28,7 +28,7 @@
             </div>
           </div>
           <%= f.input :description_short %>
-          <%= f.input :biography, 
+          <%= f.input :biography,
                       as: :summernote,
                       input_html: {
                         data: { 'summernote-config' => 'mini-list' }
@@ -42,6 +42,7 @@
           </h5>
         </div>
         <div class="card-body">
+          <p><em><%= t("university.person.personal_data_warning") %></em></p>
           <div class="row">
             <div class="col-md-6">
               <%= f.input :email %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -265,7 +265,7 @@ en:
         iso_code: ISO 639-1 code (cf <a href="https://fr.wikipedia.org/wiki/Liste_des_codes_ISO_639-1" target="_blank">WikiPedia</a>)
         name: Name in the language (= "Français", "Deutsch", ...)
       user:
-        mobile_phone: "International format (+XX). By filling this field, you accept to receive your two-factor authentication codes via SMS."
+        mobile_phone: "International format (+XX). This number remains private. By filling this field, you accept to receive your two-factor authentication codes via SMS."
     include_blanks:
       defaults:
         language: "Select a language"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -265,7 +265,7 @@ fr:
         iso_code: Code ISO 639-1 (cf <a href="https://fr.wikipedia.org/wiki/Liste_des_codes_ISO_639-1" target="_blank">WikiPedia</a>)
         name: Nom dans la langue (= "Français", "Deutsch", ...)
       user:
-        mobile_phone: "Format international (+XX). En renseignant ce champ, vous acceptez de recevoir vos codes de double authentification par SMS."
+        mobile_phone: "Format international (+XX). Ce numéro reste privé. En renseignant ce champ, vous acceptez de recevoir vos codes de double authentification par SMS."
     include_blanks:
       defaults:
         language: "Sélectionnez une langue"

--- a/config/locales/university/en.yml
+++ b/config/locales/university/en.yml
@@ -191,6 +191,7 @@ en:
         no_organization_hint_html: "If the organization is not in the list, you can <a href=\"%{url}\">create it</a>"
         no_organization_hint_no_access_html: "If the organization is not in the list, you should ask to create it"
         period: Period
-    taught_programs: Taught programs
+      personal_data_warning: Warning! The information provided below can be publicly visible on the websites and the extranets about you.
+      taught_programs: Taught programs
     sso: SSO
     sso_key: SSO Key

--- a/config/locales/university/fr.yml
+++ b/config/locales/university/fr.yml
@@ -191,6 +191,7 @@ fr:
         no_organization_hint_html: "Si l'entreprise n'apparait pas dans la liste, vous pouvez la <a href=\"%{url}\">créer</a>"
         no_organization_hint_no_access_html: "Si l'entreprise n'apparait pas dans la liste, il faut demander à la créer"
         period: Période
+      personal_data_warning: Attention ! Les informations renseignées ici sont susceptibles d'être visibles publiquement sur les sites web et les extranets vous concernant.
       taught_programs: Formations enseignées
     sso: SSO
     sso_key: Clé sur le SSO


### PR DESCRIPTION
On explique que les informations de la personne sont susceptibles d'être visibles, alors que le numéro au niveau de l'utilisateur reste privé dans le cadre du 2FA. La sync pour le numéro est donc désactivée.