### PR TITLE
Ajout du rich text avec liens uniquement dans le texte des blocs image

### DIFF
--- a/app/models/communication/block/template/image.rb
+++ b/app/models/communication/block/template/image.rb
@@ -3,7 +3,7 @@ class Communication::Block::Template::Image < Communication::Block::Template::Ba
   has_component :image, :image
   has_component :alt, :string
   has_component :credit, :rich_text
-  has_component :text, :text
+  has_component :text, :rich_text
 
   protected
 

--- a/app/views/admin/communication/blocks/templates/image/_edit.html.erb
+++ b/app/views/admin/communication/blocks/templates/image/_edit.html.erb
@@ -10,6 +10,7 @@
           label: t('admin.communication.blocks.components.image.credit.label'),
           placeholder: t('admin.communication.blocks.components.image.credit.placeholder'),
           summernote_config: 'link' %>
-    <%= block_component_edit :text %>
+    <%= block_component_edit :text,
+          summernote_config: 'link' %>
   </div>
 </div>


### PR DESCRIPTION
Fix #691 

Attention @alexisben @Olivia206 il faut adapter le thème pour recevoir des balises