### PR TITLE
SHA256 migration : Rails.application.secret_key_base

### DIFF
--- a/db/migrate/20230106132654_migrate_to_rails7_sha256_signature.rb
+++ b/db/migrate/20230106132654_migrate_to_rails7_sha256_signature.rb
@@ -35,7 +35,7 @@ class MigrateToRails7Sha256Signature < ActiveRecord::Migration[7.0]
       begin
         # Try to find blob with ID from SHA1-signed_id
         key_generator = ActiveSupport::KeyGenerator.new(
-          Rails.application.secrets.secret_key_base,
+          Rails.application.secret_key_base,
           iterations: 1000,
           hash_digest_class: OpenSSL::Digest::SHA1
         )


### PR DESCRIPTION
On pase par Rails.application.secret_key_base qui s'occupera d'aller chercher la variable d'environnement en production