### PR TITLE
Rename description_short to chapo

### DIFF
--- a/app/controllers/admin/communication/websites/pages_controller.rb
+++ b/app/controllers/admin/communication/websites/pages_controller.rb
@@ -102,7 +102,7 @@ class Admin::Communication::Websites::PagesController < Admin::Communication::We
     params.require(:communication_website_page)
           .permit(
             :communication_website_id, :title, :breadcrumb_title, :bodyclass,
-            :description, :description_short, :header_text, :text, :slug, :published, :full_width,
+            :chapo, :description, :header_text, :text, :slug, :published, :full_width,
             :featured_image, :featured_image_delete, :featured_image_infos, :featured_image_alt, :featured_image_credit,
             :parent_id, :language_id
           )

--- a/app/controllers/admin/communication/websites/posts_controller.rb
+++ b/app/controllers/admin/communication/websites/posts_controller.rb
@@ -95,7 +95,7 @@ class Admin::Communication::Websites::PostsController < Admin::Communication::We
   def post_params
     params.require(:communication_website_post)
           .permit(
-            :university_id, :website_id, :title, :description, :description_short, :text,
+            :university_id, :website_id, :title, :chapo, :description, :text,
             :published, :published_at, :slug, :pinned,
             :featured_image, :featured_image_delete, :featured_image_infos, :featured_image_alt, :featured_image_credit,
             :author_id, :language_id, category_ids: []

--- a/app/controllers/admin/education/diplomas_controller.rb
+++ b/app/controllers/admin/education/diplomas_controller.rb
@@ -64,6 +64,6 @@ class Admin::Education::DiplomasController < Admin::Education::ApplicationContro
 
   def diploma_params
     params.require(:education_diploma)
-          .permit(:name, :short_name, :description_short, :level, :ects, :duration)
+          .permit(:name, :short_name, :chapo, :level, :ects, :duration)
   end
 end

--- a/app/controllers/admin/education/programs_controller.rb
+++ b/app/controllers/admin/education/programs_controller.rb
@@ -110,7 +110,7 @@ class Admin::Education::ProgramsController < Admin::Education::ApplicationContro
 
   def program_params
     params.require(:education_program).permit(
-      :name, :short_name, :slug, :capacity, :continuing, :initial, :apprenticeship, :description, :description_short, :published,
+      :name, :short_name, :slug, :capacity, :continuing, :initial, :apprenticeship, :chapo, :description, :published,
       :featured_image, :featured_image_delete, :featured_image_infos, :featured_image_alt, :featured_image_credit,
       :prerequisites, :objectives, :presentation, :registration, :pedagogy, :content, :registration_url,
       :evaluation, :accessibility, :pricing, :contacts, :opportunities, :results, :other,  :main_information,

--- a/app/controllers/admin/university/organizations_controller.rb
+++ b/app/controllers/admin/university/organizations_controller.rb
@@ -69,11 +69,11 @@ class Admin::University::OrganizationsController < Admin::University::Applicatio
   def organization_params
     params.require(:university_organization)
           .permit(
-            :name, :long_name, :slug, :description, :description_short, :active, :siren, :kind,
+            :name, :long_name, :slug, :chapo, :description, :active, :siren, :kind,
             :address, :zipcode, :city, :country, :text,
             :url, :phone, :email,
-            :logo, :logo_delete, :logo_infos, 
-            :logo_on_dark_background, :logo_on_dark_background_delete, :logo_on_dark_background_infos, 
+            :logo, :logo_delete, :logo_infos,
+            :logo_on_dark_background, :logo_on_dark_background_delete, :logo_on_dark_background_infos,
           )
   end
 end

--- a/app/controllers/admin/university/people_controller.rb
+++ b/app/controllers/admin/university/people_controller.rb
@@ -74,7 +74,7 @@ class Admin::University::PeopleController < Admin::University::ApplicationContro
       :slug, :first_name, :last_name, :email, :gender, :birthdate,
       :phone_mobile, :phone_professional, :phone_personal,
       :address, :zipcode, :city, :country,
-      :description, :description_short,
+      :chapo, :description,
       :biography,  :picture, :picture_delete, :picture_infos,
       :habilitation, :tenure, :url, :linkedin, :twitter,
       :is_researcher, :is_teacher, :is_administration, :is_alumnus,

--- a/app/controllers/extranet/personal_data_controller.rb
+++ b/app/controllers/extranet/personal_data_controller.rb
@@ -26,7 +26,7 @@ class Extranet::PersonalDataController < Extranet::ApplicationController
   def person_params
     params.require(:university_person)
           .permit(
-            :gender, :birthdate, :description_short, :biography,
+            :gender, :birthdate, :chapo, :biography,
             :phone_mobile, :phone_professional, :phone_personal,
             :address, :zipcode, :city, :country,
             :url, :linkedin, :twitter

--- a/app/models/communication/website/page.rb
+++ b/app/models/communication/website/page.rb
@@ -5,8 +5,8 @@
 #  id                       :uuid             not null, primary key
 #  bodyclass                :string
 #  breadcrumb_title         :string
+#  chapo                    :text
 #  description              :text
-#  description_short        :text
 #  featured_image_alt       :string
 #  featured_image_credit    :text
 #  full_width               :boolean          default(FALSE)

--- a/app/models/communication/website/page/accessibility.rb
+++ b/app/models/communication/website/page/accessibility.rb
@@ -5,8 +5,8 @@
 #  id                       :uuid             not null, primary key
 #  bodyclass                :string
 #  breadcrumb_title         :string
+#  chapo                    :text
 #  description              :text
-#  description_short        :text
 #  featured_image_alt       :string
 #  featured_image_credit    :text
 #  full_width               :boolean          default(FALSE)

--- a/app/models/communication/website/page/administrator.rb
+++ b/app/models/communication/website/page/administrator.rb
@@ -5,8 +5,8 @@
 #  id                       :uuid             not null, primary key
 #  bodyclass                :string
 #  breadcrumb_title         :string
+#  chapo                    :text
 #  description              :text
-#  description_short        :text
 #  featured_image_alt       :string
 #  featured_image_credit    :text
 #  full_width               :boolean          default(FALSE)

--- a/app/models/communication/website/page/author.rb
+++ b/app/models/communication/website/page/author.rb
@@ -5,8 +5,8 @@
 #  id                       :uuid             not null, primary key
 #  bodyclass                :string
 #  breadcrumb_title         :string
+#  chapo                    :text
 #  description              :text
-#  description_short        :text
 #  featured_image_alt       :string
 #  featured_image_credit    :text
 #  full_width               :boolean          default(FALSE)

--- a/app/models/communication/website/page/communication_post.rb
+++ b/app/models/communication/website/page/communication_post.rb
@@ -5,8 +5,8 @@
 #  id                       :uuid             not null, primary key
 #  bodyclass                :string
 #  breadcrumb_title         :string
+#  chapo                    :text
 #  description              :text
-#  description_short        :text
 #  featured_image_alt       :string
 #  featured_image_credit    :text
 #  full_width               :boolean          default(FALSE)

--- a/app/models/communication/website/page/education_diploma.rb
+++ b/app/models/communication/website/page/education_diploma.rb
@@ -5,8 +5,8 @@
 #  id                       :uuid             not null, primary key
 #  bodyclass                :string
 #  breadcrumb_title         :string
+#  chapo                    :text
 #  description              :text
-#  description_short        :text
 #  featured_image_alt       :string
 #  featured_image_credit    :text
 #  full_width               :boolean          default(FALSE)

--- a/app/models/communication/website/page/education_program.rb
+++ b/app/models/communication/website/page/education_program.rb
@@ -5,8 +5,8 @@
 #  id                       :uuid             not null, primary key
 #  bodyclass                :string
 #  breadcrumb_title         :string
+#  chapo                    :text
 #  description              :text
-#  description_short        :text
 #  featured_image_alt       :string
 #  featured_image_credit    :text
 #  full_width               :boolean          default(FALSE)

--- a/app/models/communication/website/page/home.rb
+++ b/app/models/communication/website/page/home.rb
@@ -5,8 +5,8 @@
 #  id                       :uuid             not null, primary key
 #  bodyclass                :string
 #  breadcrumb_title         :string
+#  chapo                    :text
 #  description              :text
-#  description_short        :text
 #  featured_image_alt       :string
 #  featured_image_credit    :text
 #  full_width               :boolean          default(FALSE)

--- a/app/models/communication/website/page/legal_term.rb
+++ b/app/models/communication/website/page/legal_term.rb
@@ -5,8 +5,8 @@
 #  id                       :uuid             not null, primary key
 #  bodyclass                :string
 #  breadcrumb_title         :string
+#  chapo                    :text
 #  description              :text
-#  description_short        :text
 #  featured_image_alt       :string
 #  featured_image_credit    :text
 #  full_width               :boolean          default(FALSE)

--- a/app/models/communication/website/page/organization.rb
+++ b/app/models/communication/website/page/organization.rb
@@ -5,8 +5,8 @@
 #  id                       :uuid             not null, primary key
 #  bodyclass                :string
 #  breadcrumb_title         :string
+#  chapo                    :text
 #  description              :text
-#  description_short        :text
 #  featured_image_alt       :string
 #  featured_image_credit    :text
 #  full_width               :boolean          default(FALSE)

--- a/app/models/communication/website/page/person.rb
+++ b/app/models/communication/website/page/person.rb
@@ -5,8 +5,8 @@
 #  id                       :uuid             not null, primary key
 #  bodyclass                :string
 #  breadcrumb_title         :string
+#  chapo                    :text
 #  description              :text
-#  description_short        :text
 #  featured_image_alt       :string
 #  featured_image_credit    :text
 #  full_width               :boolean          default(FALSE)

--- a/app/models/communication/website/page/privacy_policy.rb
+++ b/app/models/communication/website/page/privacy_policy.rb
@@ -5,8 +5,8 @@
 #  id                       :uuid             not null, primary key
 #  bodyclass                :string
 #  breadcrumb_title         :string
+#  chapo                    :text
 #  description              :text
-#  description_short        :text
 #  featured_image_alt       :string
 #  featured_image_credit    :text
 #  full_width               :boolean          default(FALSE)

--- a/app/models/communication/website/page/research_paper.rb
+++ b/app/models/communication/website/page/research_paper.rb
@@ -5,8 +5,8 @@
 #  id                       :uuid             not null, primary key
 #  bodyclass                :string
 #  breadcrumb_title         :string
+#  chapo                    :text
 #  description              :text
-#  description_short        :text
 #  featured_image_alt       :string
 #  featured_image_credit    :text
 #  full_width               :boolean          default(FALSE)

--- a/app/models/communication/website/page/research_volume.rb
+++ b/app/models/communication/website/page/research_volume.rb
@@ -5,8 +5,8 @@
 #  id                       :uuid             not null, primary key
 #  bodyclass                :string
 #  breadcrumb_title         :string
+#  chapo                    :text
 #  description              :text
-#  description_short        :text
 #  featured_image_alt       :string
 #  featured_image_credit    :text
 #  full_width               :boolean          default(FALSE)

--- a/app/models/communication/website/page/researcher.rb
+++ b/app/models/communication/website/page/researcher.rb
@@ -5,8 +5,8 @@
 #  id                       :uuid             not null, primary key
 #  bodyclass                :string
 #  breadcrumb_title         :string
+#  chapo                    :text
 #  description              :text
-#  description_short        :text
 #  featured_image_alt       :string
 #  featured_image_credit    :text
 #  full_width               :boolean          default(FALSE)

--- a/app/models/communication/website/page/sitemap.rb
+++ b/app/models/communication/website/page/sitemap.rb
@@ -5,8 +5,8 @@
 #  id                       :uuid             not null, primary key
 #  bodyclass                :string
 #  breadcrumb_title         :string
+#  chapo                    :text
 #  description              :text
-#  description_short        :text
 #  featured_image_alt       :string
 #  featured_image_credit    :text
 #  full_width               :boolean          default(FALSE)

--- a/app/models/communication/website/page/teacher.rb
+++ b/app/models/communication/website/page/teacher.rb
@@ -5,8 +5,8 @@
 #  id                       :uuid             not null, primary key
 #  bodyclass                :string
 #  breadcrumb_title         :string
+#  chapo                    :text
 #  description              :text
-#  description_short        :text
 #  featured_image_alt       :string
 #  featured_image_credit    :text
 #  full_width               :boolean          default(FALSE)

--- a/app/models/communication/website/post.rb
+++ b/app/models/communication/website/post.rb
@@ -3,8 +3,8 @@
 # Table name: communication_website_posts
 #
 #  id                       :uuid             not null, primary key
+#  chapo                    :text
 #  description              :text
-#  description_short        :text
 #  featured_image_alt       :string
 #  featured_image_credit    :text
 #  github_path              :text
@@ -88,7 +88,7 @@ class Communication::Website::Post < ApplicationRecord
   scope :for_search_term, -> (term) {
     where("
       unaccent(communication_website_posts.description) ILIKE unaccent(:term) OR
-      unaccent(communication_website_posts.description_short) ILIKE unaccent(:term) OR
+      unaccent(communication_website_posts.chapo) ILIKE unaccent(:term) OR
       unaccent(communication_website_posts.text) ILIKE unaccent(:term) OR
       unaccent(communication_website_posts.title) ILIKE unaccent(:term)
     ", term: "%#{sanitize_sql_like(term)}%")

--- a/app/models/education/diploma.rb
+++ b/app/models/education/diploma.rb
@@ -2,17 +2,17 @@
 #
 # Table name: education_diplomas
 #
-#  id                :uuid             not null, primary key
-#  description_short :text
-#  duration          :text
-#  ects              :integer
-#  level             :integer          default("not_applicable")
-#  name              :string
-#  short_name        :string
-#  slug              :string
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  university_id     :uuid             not null, indexed
+#  id            :uuid             not null, primary key
+#  chapo         :text
+#  duration      :text
+#  ects          :integer
+#  level         :integer          default("not_applicable")
+#  name          :string
+#  short_name    :string
+#  slug          :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  university_id :uuid             not null, indexed
 #
 # Indexes
 #

--- a/app/models/education/program.rb
+++ b/app/models/education/program.rb
@@ -6,11 +6,11 @@
 #  accessibility         :text
 #  apprenticeship        :boolean
 #  capacity              :integer
+#  chapo                 :text
 #  contacts              :text
 #  content               :text
 #  continuing            :boolean
 #  description           :text
-#  description_short     :text
 #  duration              :text
 #  evaluation            :text
 #  featured_image_alt    :string

--- a/app/models/university/organization.rb
+++ b/app/models/university/organization.rb
@@ -2,27 +2,27 @@
 #
 # Table name: university_organizations
 #
-#  id                :uuid             not null, primary key
-#  active            :boolean          default(TRUE)
-#  address           :string
-#  city              :string
-#  country           :string
-#  description       :text
-#  description_short :text
-#  email             :string
-#  kind              :integer          default("company")
-#  long_name         :string
-#  name              :string
-#  nic               :string
-#  phone             :string
-#  siren             :string
-#  slug              :string
-#  text              :text
-#  url               :string
-#  zipcode           :string
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  university_id     :uuid             not null, indexed
+#  id            :uuid             not null, primary key
+#  active        :boolean          default(TRUE)
+#  address       :string
+#  chapo         :text
+#  city          :string
+#  country       :string
+#  description   :text
+#  email         :string
+#  kind          :integer          default("company")
+#  long_name     :string
+#  name          :string
+#  nic           :string
+#  phone         :string
+#  siren         :string
+#  slug          :string
+#  text          :text
+#  url           :string
+#  zipcode       :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  university_id :uuid             not null, indexed
 #
 # Indexes
 #

--- a/app/models/university/person.rb
+++ b/app/models/university/person.rb
@@ -6,10 +6,10 @@
 #  address            :string
 #  biography          :text
 #  birthdate          :date
+#  chapo              :text
 #  city               :string
 #  country            :string
 #  description        :text
-#  description_short  :text
 #  email              :string
 #  first_name         :string
 #  gender             :integer
@@ -148,7 +148,7 @@ class University::Person < ApplicationRecord
       unaccent(university_people.phone_professional) ILIKE unaccent(:term) OR
       unaccent(university_people.biography) ILIKE unaccent(:term) OR
       unaccent(university_people.description) ILIKE unaccent(:term) OR
-      unaccent(university_people.description_short) ILIKE unaccent(:term) OR
+      unaccent(university_people.chapo) ILIKE unaccent(:term) OR
       unaccent(university_people.twitter) ILIKE unaccent(:term) OR
       unaccent(university_people.linkedin) ILIKE unaccent(:term) OR
       unaccent(university_people.address) ILIKE unaccent(:term) OR

--- a/app/models/university/person/administrator.rb
+++ b/app/models/university/person/administrator.rb
@@ -6,10 +6,10 @@
 #  address            :string
 #  biography          :text
 #  birthdate          :date
+#  chapo              :text
 #  city               :string
 #  country            :string
 #  description        :text
-#  description_short  :text
 #  email              :string
 #  first_name         :string
 #  gender             :integer

--- a/app/models/university/person/alumnus.rb
+++ b/app/models/university/person/alumnus.rb
@@ -6,10 +6,10 @@
 #  address            :string
 #  biography          :text
 #  birthdate          :date
+#  chapo              :text
 #  city               :string
 #  country            :string
 #  description        :text
-#  description_short  :text
 #  email              :string
 #  first_name         :string
 #  gender             :integer

--- a/app/models/university/person/author.rb
+++ b/app/models/university/person/author.rb
@@ -6,10 +6,10 @@
 #  address            :string
 #  biography          :text
 #  birthdate          :date
+#  chapo              :text
 #  city               :string
 #  country            :string
 #  description        :text
-#  description_short  :text
 #  email              :string
 #  first_name         :string
 #  gender             :integer

--- a/app/models/university/person/researcher.rb
+++ b/app/models/university/person/researcher.rb
@@ -6,10 +6,10 @@
 #  address            :string
 #  biography          :text
 #  birthdate          :date
+#  chapo              :text
 #  city               :string
 #  country            :string
 #  description        :text
-#  description_short  :text
 #  email              :string
 #  first_name         :string
 #  gender             :integer

--- a/app/models/university/person/teacher.rb
+++ b/app/models/university/person/teacher.rb
@@ -6,10 +6,10 @@
 #  address            :string
 #  biography          :text
 #  birthdate          :date
+#  chapo              :text
 #  city               :string
 #  country            :string
 #  description        :text
-#  description_short  :text
 #  email              :string
 #  first_name         :string
 #  gender             :integer

--- a/app/views/admin/application/chapo/_form.html.erb
+++ b/app/views/admin/application/chapo/_form.html.erb
@@ -1,4 +1,4 @@
-<%= f.input :description_short, 
-            input_html: { 
-              value: about.description_short&.gsub('&amp;', '&') 
+<%= f.input :chapo,
+            input_html: {
+              value: about.chapo&.gsub('&amp;', '&')
             } %>

--- a/app/views/admin/application/chapo/_show.html.erb
+++ b/app/views/admin/application/chapo/_show.html.erb
@@ -1,11 +1,11 @@
-<% unless about.description_short.blank? %>
+<% unless about.chapo.blank? %>
   <div class="card flex-fill w-100">
     <div class="card-header">
-      <h2 class="card-title mb-0 h5"><%= about.class.human_attribute_name('description_short') %></h2>
+      <h2 class="card-title mb-0 h5"><%= about.class.human_attribute_name('chapo') %></h2>
     </div>
     <div class="card-body">
       <p class="lead">
-        <%= sanitize about.description_short %>
+        <%= sanitize about.chapo %>
       </p>
     </div>
   </div>

--- a/app/views/admin/application/chapo/_static.html.erb
+++ b/app/views/admin/application/chapo/_static.html.erb
@@ -1,2 +1,4 @@
+chapo: >
+  <%= prepare_text_for_static @about.chapo %>
 description_short: >
-  <%= prepare_text_for_static @about.description_short %>
+  <%= prepare_text_for_static @about.chapo %>

--- a/app/views/admin/communication/blocks/templates/pages/_preview.html.erb
+++ b/app/views/admin/communication/blocks/templates/pages/_preview.html.erb
@@ -12,7 +12,7 @@
                             class: 'img-fluid mb-3' %>
         <% end %>
         <% if @block.template.show_description %>
-          <p><%= element.description_short %></p>
+          <p><%= element.chapo %></p>
         <% end %>
       </div>
     <% end %>

--- a/app/views/admin/communication/blocks/templates/posts/_preview.html.erb
+++ b/app/views/admin/communication/blocks/templates/posts/_preview.html.erb
@@ -5,7 +5,7 @@
         <article class="post">
           <div>
             <p class="title"><%= post %></p>
-            <p><%= post.description_short %></p>
+            <p><%= post.chapo %></p>
             <time datetime="<%= post.published_at %>"><%= post.published_at.to_date %></time>
           </div>
           <% if post.best_featured_image.attached? %>

--- a/app/views/admin/communication/websites/categories/static.html.erb
+++ b/app/views/admin/communication/websites/categories/static.html.erb
@@ -15,6 +15,8 @@ position: <%= @about.position %>
 <%= render 'admin/communication/unsplash/static' %>
 description: >
   <%= prepare_text_for_static @about.description %>
+chapo: >
+  <%= prepare_text_for_static @about.text %>
 description_short: >
   <%= prepare_text_for_static @about.text %>
 <%= render 'admin/communication/blocks/static', about: @about %>

--- a/app/views/admin/education/programs/show.html.erb
+++ b/app/views/admin/education/programs/show.html.erb
@@ -16,10 +16,10 @@
           </h3>
           <p><%= link_to @program.diploma, [:admin, @program.diploma] if @program.diploma %></p>
           <h3 class="h5 mt-4">
-            <%= Education::Program.human_attribute_name('description_short') %>
+            <%= Education::Program.human_attribute_name('chapo') %>
           </h3>
           <p class="lead">
-            <%= sanitize @program.description_short %>
+            <%= sanitize @program.chapo %>
           </p>
           <% if @program.schools.any? %>
             <h3 class="h5 mt-4">
@@ -58,7 +58,7 @@
               <%= Education::Program.human_attribute_name('downloadable_summary') %>
             </h3>
             <p><%= link_to "#{@program.downloadable_summary.filename} (#{ number_to_human_size @program.downloadable_summary.blob.byte_size })",
-                            url_for(@program.downloadable_summary), 
+                            url_for(@program.downloadable_summary),
                             target: :_blank %></p>
           <% end %>
         </div>

--- a/app/views/admin/education/programs/show.html.erb
+++ b/app/views/admin/education/programs/show.html.erb
@@ -2,6 +2,7 @@
 
 <div class="row">
   <div class="col-lg-8 col-xxl-9">
+    <%= render 'admin/application/chapo/show', about: @program %>
     <%= render 'admin/education/programs/forms/part',
                 part: :essential,
                 collapsed: false do %>
@@ -15,12 +16,6 @@
             <%= Education::Program.human_attribute_name('diploma') %>
           </h3>
           <p><%= link_to @program.diploma, [:admin, @program.diploma] if @program.diploma %></p>
-          <h3 class="h5 mt-4">
-            <%= Education::Program.human_attribute_name('chapo') %>
-          </h3>
-          <p class="lead">
-            <%= sanitize @program.chapo %>
-          </p>
           <% if @program.schools.any? %>
             <h3 class="h5 mt-4">
               <%= Education::Program.human_attribute_name('schools') %>

--- a/app/views/admin/research/journals/papers/static.html.erb
+++ b/app/views/admin/research/journals/papers/static.html.erb
@@ -18,6 +18,7 @@ researchers:
 <% @about.people.each do |person| %>
 - "<%= person.slug %>"
 <% end %>
+chapo: "<%= @about.abstract %>"
 description_short: "<%= @about.abstract %>"
 abstract: "<%= @about.abstract %>"
 references: "<%= @about.references %>"

--- a/app/views/admin/research/journals/papers/static.html.erb
+++ b/app/views/admin/research/journals/papers/static.html.erb
@@ -18,7 +18,6 @@ researchers:
 <% @about.people.each do |person| %>
 - "<%= person.slug %>"
 <% end %>
-chapo: "<%= @about.abstract %>"
 description_short: "<%= @about.abstract %>"
 abstract: "<%= @about.abstract %>"
 references: "<%= @about.references %>"

--- a/app/views/admin/university/organizations/_form.html.erb
+++ b/app/views/admin/university/organizations/_form.html.erb
@@ -10,7 +10,7 @@
         </div>
         <div class="card-body">
           <%= f.input :name %>
-          <%= f.input :description_short %>
+          <%= f.input :chapo %>
           <%= f.input :text,
                       as: :summernote,
                       input_html: {

--- a/app/views/admin/university/organizations/_form.html.erb
+++ b/app/views/admin/university/organizations/_form.html.erb
@@ -10,7 +10,7 @@
         </div>
         <div class="card-body">
           <%= f.input :name %>
-          <%= f.input :chapo %>
+          <%= render 'admin/application/chapo/form', f: f, about: organization %>
           <%= f.input :text,
                       as: :summernote,
                       input_html: {

--- a/app/views/admin/university/people/_form.html.erb
+++ b/app/views/admin/university/people/_form.html.erb
@@ -27,7 +27,7 @@
               <%= f.input :birthdate, discard_year: true, include_blank: true %>
             </div>
           </div>
-          <%= f.input :chapo %>
+          <%= render 'admin/application/chapo/form', f: f, about: person %>
           <%= f.input :biography,
                       as: :summernote,
                       input_html: {

--- a/app/views/admin/university/people/_form.html.erb
+++ b/app/views/admin/university/people/_form.html.erb
@@ -27,7 +27,7 @@
               <%= f.input :birthdate, discard_year: true, include_blank: true %>
             </div>
           </div>
-          <%= f.input :description_short %>
+          <%= f.input :chapo %>
           <%= f.input :biography,
                       as: :summernote,
                       input_html: {

--- a/app/views/admin/university/people/_main_infos.html.erb
+++ b/app/views/admin/university/people/_main_infos.html.erb
@@ -32,9 +32,9 @@
           <p><%= value %></p>
         <% end %>
 
-        <% unless person.description_short.blank? %>
-          <h3 class="h5"><%= University::Person.human_attribute_name('description_short') %></h3>
-          <%= simple_format person.description_short %>
+        <% unless person.chapo.blank? %>
+          <h3 class="h5"><%= University::Person.human_attribute_name('chapo') %></h3>
+          <%= simple_format person.chapo %>
         <% end %>
         <% unless person.biography.blank? %>
           <h3 class="h5"><%= University::Person.human_attribute_name('biography') %></h3>

--- a/app/views/admin/university/people/_main_infos.html.erb
+++ b/app/views/admin/university/people/_main_infos.html.erb
@@ -31,11 +31,6 @@
           <h3 class="h5"><%= University::Person.human_attribute_name(property) %></h3>
           <p><%= value %></p>
         <% end %>
-
-        <% unless person.chapo.blank? %>
-          <h3 class="h5"><%= University::Person.human_attribute_name('chapo') %></h3>
-          <%= simple_format person.chapo %>
-        <% end %>
         <% unless person.biography.blank? %>
           <h3 class="h5"><%= University::Person.human_attribute_name('biography') %></h3>
           <%= person.biography %>

--- a/config/locales/communication/en.yml
+++ b/config/locales/communication/en.yml
@@ -112,9 +112,9 @@ en:
       communication/website/page:
         bodyclass: Specific CSS class
         breadcrumb_title: Title in breadcrumbs
+        chapo: Lead text
         children: Children pages
         description: Meta description
-        description_short: Lead text
         featured_image: Featured image
         featured_image_alt: Alt text
         full_width: Full width
@@ -131,8 +131,8 @@ en:
         author: Author
         category: Category
         categories: Categories
+        chapo: Lead text
         description: Meta description
-        description_short: Lead text
         featured_image: Featured image
         featured_image_alt: Alt text
         featured_image_credit: Credit

--- a/config/locales/communication/fr.yml
+++ b/config/locales/communication/fr.yml
@@ -112,9 +112,9 @@ fr:
       communication/website/page:
         bodyclass: Classe CSS spécifique
         breadcrumb_title: Nom affiché dans le fil d'ariane
+        chapo: Chapô
         children: Pages enfants
         description: Description pour le référencement naturel
-        description_short: Chapô
         featured_image: Image à la une
         featured_image_alt: Texte alternatif
         full_width: Pleine largeur
@@ -131,8 +131,8 @@ fr:
         author: Auteur·rice
         category: Catégorie
         categories: Catégories
+        chapo: Chapô
         description: Description pour le référencement naturel
-        description_short: Chapô
         featured_image: Image à la une
         featured_image_alt: Texte alternatif
         featured_image_credit: Crédit
@@ -593,7 +593,7 @@ fr:
             slug: formations
             title: "Formations"
           home:
-            slug: 
+            slug:
             title: Accueil
           legal_term:
             slug: mentions-legales

--- a/config/locales/education/en.yml
+++ b/config/locales/education/en.yml
@@ -28,21 +28,21 @@ en:
         school: School
         year: Year
       education/diploma:
-        name: Name
-        short_name: Short name
-        level: Level
-        programs: Programs
+        chapo: Lead text
         duration: Duration
         ects: ECTS
-        description_short: Lead text
+        level: Level
+        name: Name
+        programs: Programs
+        short_name: Short name
       education/program:
         accessibility: Accessibilité
         apprenticeship: Apprenticeship
         capacity: Capacity
+        chapo: Lead text
         contacts: Contacts
         continuing: Continuing training
         description: Meta Description
-        description_short: Lead text
         diploma: Diploma
         duration: Duration
         downloadable_summary: Downloadable summary

--- a/config/locales/education/fr.yml
+++ b/config/locales/education/fr.yml
@@ -28,21 +28,21 @@ fr:
         school: École
         year: Année
       education/diploma:
-        name: Nom
-        short_name: Nom abrégé
-        level: Niveau
-        programs: Formations
+        chapo: Chapô
         duration: Durée
         ects: Crédits ECTS
-        description_short: Chapô
+        level: Niveau
+        name: Nom
+        programs: Formations
+        short_name: Nom abrégé
       education/program:
         accessibility: Accessibilité
         apprenticeship: Apprentissage
         capacity: Capacité
+        chapo: Chapô
         contacts: Contacts
         continuing: Formation continue
         description: Meta Description
-        description_short: Chapô
         diploma: Diplôme
         duration: Durée
         downloadable_summary: Document de synthèse téléchargeable

--- a/config/locales/university/en.yml
+++ b/config/locales/university/en.yml
@@ -30,12 +30,12 @@ en:
         author: Author
         biography: Biography
         birthdate: Birthdate
+        chapo: Lead text
         city: City
         communication_website_posts: Posts
         contacts: Contact information
         country: Country
         description: Meta description
-        description_short: Lead text
         education_programs: Programs
         email: Email
         essentials: Essentials
@@ -81,24 +81,24 @@ en:
         person: Person
         target_id: ''
       university/organization:
-        name: Name
-        long_name: Long name
-        description: Meta description
-        description_short: Lead text
-        text: Text
-        contact: Contact information
-        legal: Legal information
         address: Address
-        zipcode: Zipcode
+        chapo: Lead text
         city: City
+        contact: Contact information
         country: Country
-        url: Website
-        phone: Telephone
+        description: Meta description
         email: Email
+        kind: Kind
+        legal: Legal information
         logo: Logo for light backgrounds (default)
         logo_on_dark_background: Logo for dark backgrounds (optional)
-        kind: Kind
+        long_name: Long name
+        name: Name
+        phone: Telephone
         siren: Legal identification number
+        text: Text
+        url: Website
+        zipcode: Zipcode
       university/role:
         description: Description
         people: People

--- a/config/locales/university/fr.yml
+++ b/config/locales/university/fr.yml
@@ -30,12 +30,12 @@ fr:
         author: Auteur·rice
         biography: Biographie
         birthdate: Anniversaire
+        chapo: Chapô
         city: Ville
         communication_website_posts: Actualités
         contacts: Coordonnées
         country: Pays
         description: Meta description
-        description_short: Chapô
         education_programs: Formations
         email: Email
         essentials: Informations essentielles
@@ -81,24 +81,24 @@ fr:
         person: Personne
         target_id: ''
       university/organization:
-        name: Nom
-        long_name: Nom complet
-        description: Meta description
-        description_short: Chapô
-        text: Texte
-        contact: Informations de contact
-        legal: Informations légales
         address: Adresse
-        zipcode: Code postal
+        chapo: Chapô
         city: Ville
+        contact: Informations de contact
         country: Pays
-        url: Site Web
-        phone: Téléphone
+        description: Meta description
         email: Email
+        kind: Type
+        legal: Informations légales
         logo: Logo sur fond clair (par défaut)
         logo_on_dark_background: Logo sur fond sombre (optionnel)
-        kind: Type
+        long_name: Nom complet
+        name: Nom
+        phone: Téléphone
         siren: Numéro de SIREN
+        text: Texte
+        url: Site Web
+        zipcode: Code postal
       university/role:
         description: Description
         people: Personnes

--- a/db/migrate/20230106171225_rename_description_short_to_chapo.rb
+++ b/db/migrate/20230106171225_rename_description_short_to_chapo.rb
@@ -1,0 +1,10 @@
+class RenameDescriptionShortToChapo < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :communication_website_pages, :description_short, :chapo
+    rename_column :communication_website_posts, :description_short, :chapo
+    rename_column :education_diplomas, :description_short, :chapo
+    rename_column :education_programs, :description_short, :chapo
+    rename_column :university_organizations, :description_short, :chapo
+    rename_column :university_people, :description_short, :chapo
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_06_132654) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_06_171225) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -314,7 +314,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_06_132654) do
     t.text "github_path"
     t.string "featured_image_alt"
     t.text "text"
-    t.text "description_short"
+    t.text "chapo"
     t.string "breadcrumb_title"
     t.text "header_text"
     t.integer "kind"
@@ -358,7 +358,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_06_132654) do
     t.boolean "pinned", default: false
     t.string "featured_image_alt"
     t.text "text"
-    t.text "description_short"
+    t.text "chapo"
     t.uuid "language_id"
     t.text "featured_image_credit"
     t.index ["author_id"], name: "index_communication_website_posts_on_author_id"
@@ -465,7 +465,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_06_132654) do
     t.datetime "updated_at", null: false
     t.integer "ects"
     t.text "duration"
-    t.text "description_short"
+    t.text "chapo"
     t.index ["university_id"], name: "index_education_diplomas_on_university_id"
   end
 
@@ -503,7 +503,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_06_132654) do
     t.boolean "initial"
     t.boolean "apprenticeship"
     t.string "registration_url"
-    t.text "description_short"
+    t.text "chapo"
     t.index ["diploma_id"], name: "index_education_programs_on_diploma_id"
     t.index ["parent_id"], name: "index_education_programs_on_parent_id"
     t.index ["university_id"], name: "index_education_programs_on_university_id"
@@ -714,7 +714,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_06_132654) do
     t.string "slug"
     t.text "text"
     t.string "nic"
-    t.text "description_short"
+    t.text "chapo"
     t.index ["university_id"], name: "index_university_organizations_on_university_id"
   end
 
@@ -739,7 +739,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_06_132654) do
     t.string "twitter"
     t.string "linkedin"
     t.boolean "is_alumnus", default: false
-    t.text "description_short"
+    t.text "chapo"
     t.boolean "is_author"
     t.string "name"
     t.integer "gender"

--- a/test/fixtures/communication/website/posts.yml
+++ b/test/fixtures/communication/website/posts.yml
@@ -3,8 +3,8 @@
 # Table name: communication_website_posts
 #
 #  id                       :uuid             not null, primary key
+#  chapo                    :text
 #  description              :text
-#  description_short        :text
 #  featured_image_alt       :string
 #  featured_image_credit    :text
 #  github_path              :text

--- a/test/fixtures/education/diplomas.yml
+++ b/test/fixtures/education/diplomas.yml
@@ -2,17 +2,17 @@
 #
 # Table name: education_diplomas
 #
-#  id                :uuid             not null, primary key
-#  description_short :text
-#  duration          :text
-#  ects              :integer
-#  level             :integer          default("not_applicable")
-#  name              :string
-#  short_name        :string
-#  slug              :string
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  university_id     :uuid             not null, indexed
+#  id            :uuid             not null, primary key
+#  chapo         :text
+#  duration      :text
+#  ects          :integer
+#  level         :integer          default("not_applicable")
+#  name          :string
+#  short_name    :string
+#  slug          :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  university_id :uuid             not null, indexed
 #
 # Indexes
 #

--- a/test/fixtures/university/organizations.yml
+++ b/test/fixtures/university/organizations.yml
@@ -2,27 +2,27 @@
 #
 # Table name: university_organizations
 #
-#  id                :uuid             not null, primary key
-#  active            :boolean          default(TRUE)
-#  address           :string
-#  city              :string
-#  country           :string
-#  description       :text
-#  description_short :text
-#  email             :string
-#  kind              :integer          default("company")
-#  long_name         :string
-#  name              :string
-#  nic               :string
-#  phone             :string
-#  siren             :string
-#  slug              :string
-#  text              :text
-#  url               :string
-#  zipcode           :string
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  university_id     :uuid             not null, indexed
+#  id            :uuid             not null, primary key
+#  active        :boolean          default(TRUE)
+#  address       :string
+#  chapo         :text
+#  city          :string
+#  country       :string
+#  description   :text
+#  email         :string
+#  kind          :integer          default("company")
+#  long_name     :string
+#  name          :string
+#  nic           :string
+#  phone         :string
+#  siren         :string
+#  slug          :string
+#  text          :text
+#  url           :string
+#  zipcode       :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  university_id :uuid             not null, indexed
 #
 # Indexes
 #

--- a/test/models/education/diploma_test.rb
+++ b/test/models/education/diploma_test.rb
@@ -2,17 +2,17 @@
 #
 # Table name: education_diplomas
 #
-#  id                :uuid             not null, primary key
-#  description_short :text
-#  duration          :text
-#  ects              :integer
-#  level             :integer          default("not_applicable")
-#  name              :string
-#  short_name        :string
-#  slug              :string
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  university_id     :uuid             not null, indexed
+#  id            :uuid             not null, primary key
+#  chapo         :text
+#  duration      :text
+#  ects          :integer
+#  level         :integer          default("not_applicable")
+#  name          :string
+#  short_name    :string
+#  slug          :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  university_id :uuid             not null, indexed
 #
 # Indexes
 #

--- a/test/models/university/organization_test.rb
+++ b/test/models/university/organization_test.rb
@@ -2,27 +2,27 @@
 #
 # Table name: university_organizations
 #
-#  id                :uuid             not null, primary key
-#  active            :boolean          default(TRUE)
-#  address           :string
-#  city              :string
-#  country           :string
-#  description       :text
-#  description_short :text
-#  email             :string
-#  kind              :integer          default("company")
-#  long_name         :string
-#  name              :string
-#  nic               :string
-#  phone             :string
-#  siren             :string
-#  slug              :string
-#  text              :text
-#  url               :string
-#  zipcode           :string
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
-#  university_id     :uuid             not null, indexed
+#  id            :uuid             not null, primary key
+#  active        :boolean          default(TRUE)
+#  address       :string
+#  chapo         :text
+#  city          :string
+#  country       :string
+#  description   :text
+#  email         :string
+#  kind          :integer          default("company")
+#  long_name     :string
+#  name          :string
+#  nic           :string
+#  phone         :string
+#  siren         :string
+#  slug          :string
+#  text          :text
+#  url           :string
+#  zipcode       :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  university_id :uuid             not null, indexed
 #
 # Indexes
 #


### PR DESCRIPTION
Propriété Hugo `description_short` reste pour gérer le legacy, une fois que description_short a disparu dans les sites, on peut supprimer

Endroits : 
- app/views/admin/application/chapo/_static.html.erb
- app/views/admin/communication/websites/categories/static.html.erb
- app/views/admin/research/journals/papers/static.html.erb