### PR TITLE
Nettoyage des permalinks des programs

### DIFF
--- a/app/models/education/program.rb
+++ b/app/models/education/program.rb
@@ -139,10 +139,6 @@ class Education::Program < ApplicationRecord
     "#{clean_path}_index.html"
   end
 
-  def path_in_website(website)
-    Static.clean_path "#{website.special_page(Communication::Website::Page::EducationProgram)&.path}#{path}"
-  end
-
   def git_dependencies(website)
     [self] +
     siblings +

--- a/app/views/admin/education/programs/static.html.erb
+++ b/app/views/admin/education/programs/static.html.erb
@@ -9,7 +9,7 @@ administrator_involvements = @about.involvements_through_roles
 %>
 title: >
   <%= @about.name %>
-url: <%= @about.path_in_website(@website) %>
+<%= render 'admin/application/static/permalink' %>
 <%= render 'admin/application/static/design', full_width: false, toc_offcanvas: true, toc_present: true %>
 <% if @about.downloadable_summary.attached? %>
 downloadable_summary: <%= @about.downloadable_summary.blob_id %>
@@ -25,7 +25,7 @@ position: <%= @about.position %>
 parent:
   title: >
     <%= @about.parent.name %>
-  url: <%= @about.parent.path_in_website(@website) %>
+  url: <%= @about.parent.current_permalink_in_website(@website)&.path %>
 <% end %>
 <%= render 'admin/communication/unsplash/static' %>
 category: "<%= @website.categories.find_by(program_id: @about.id)&.path %>"

--- a/app/views/admin/university/people/static.html.erb
+++ b/app/views/admin/university/people/static.html.erb
@@ -46,7 +46,7 @@ teachings:
       title: >
         <%= target.to_s %>
       url: >
-        <%= target.path_in_website(@website) if target.respond_to? :path_in_website %>
+        <%= target.current_permalink_in_website(@website)&.path %>
 <% end %>
 <% end %>
 <% if @about.roles_as_administrator.any? %>
@@ -59,7 +59,7 @@ administrative_missions:
       title: >
         <%= target.to_s %>
       url: >
-        <%= target.path_in_website(@website) if target.respond_to? :path_in_website %>
+        <%= target.current_permalink_in_website(@website)&.path if target.respond_to? :current_permalink_in_website %>
 <% end %>
 <% end %>
 <%= render 'admin/communication/blocks/static', about: @about %>


### PR DESCRIPTION
On utilise maintenant le render du permalink pour le program.
Et lorsqu'on a besoin de l'url du program on utilise current_permalink_in_website(@website)&.path
Supprime la méthode 'path_in_website' qui n'est plus utilisée