### PR TITLE
Gérer la localisation de Summernote

### DIFF
--- a/app/assets/javascripts/application/plugins/summernote.js
+++ b/app/assets/javascripts/application/plugins/summernote.js
@@ -111,9 +111,12 @@ $(function () {
 
     $('[data-provider="summernote"]').each(function () {
         var config = $(this).attr('data-summernote-config'),
+            locale = $('#summernote-locale').data('locale'),
             options = {};
         config = config || 'default';
         options = configs[config];
+        // if locale is undefined, summernote use default (en-US)
+        options['lang'] = locale;
         $(this).summernote(options);
     });
 

--- a/app/controllers/application_controller/with_locale.rb
+++ b/app/controllers/application_controller/with_locale.rb
@@ -3,6 +3,13 @@ module ApplicationController::WithLocale
 
   included do
     around_action :switch_locale
+
+    helper_method :current_language
+
+  end
+
+  def current_language
+    @current_language ||= Language.find_by(iso_code: I18n.locale.to_s)
   end
 
   protected

--- a/app/controllers/server/languages_controller.rb
+++ b/app/controllers/server/languages_controller.rb
@@ -57,6 +57,6 @@ class Server::LanguagesController < Server::ApplicationController
   end
 
   def language_params
-    params.require(:language).permit(:name, :iso_code)
+    params.require(:language).permit(:name, :iso_code, :summernote_locale)
   end
 end

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -2,11 +2,12 @@
 #
 # Table name: languages
 #
-#  id         :uuid             not null, primary key
-#  iso_code   :string
-#  name       :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id                :uuid             not null, primary key
+#  iso_code          :string
+#  name              :string
+#  summernote_locale :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
 #
 class Language < ApplicationRecord
 

--- a/app/views/admin/communication/blocks/edit.html.erb
+++ b/app/views/admin/communication/blocks/edit.html.erb
@@ -104,8 +104,8 @@
       },
       initSummernote(element) {
         var config = element.getAttribute('data-summernote-config') || 'default';
-
         $(element).summernote({
+          lang: '<%= current_language.summernote_locale unless current_language.summernote_locale.blank? %>',
           toolbar: window.SUMMERNOTE_CONFIGS[config].toolbar, // Dependent of app/assets/javascripts/admin/plugins/summernote.js
           followingToolbar: true,
           disableDragAndDrop: true,

--- a/app/views/admin/layouts/themes/_appstack.html.erb
+++ b/app/views/admin/layouts/themes/_appstack.html.erb
@@ -29,4 +29,5 @@
   <%= javascript_include_tag 'admin/appstack' %>
   <%= render 'gdpr/cookie_consent' %>
   <%= render 'bugsnag' %>
+  <%= render 'summernote_localization' %>
 </body>

--- a/app/views/admin/layouts/themes/_pure.html.erb
+++ b/app/views/admin/layouts/themes/_pure.html.erb
@@ -20,4 +20,5 @@
   <%= javascript_include_tag 'admin/pure' %>
   <%= render 'gdpr/cookie_consent' %>
   <%= render 'bugsnag' %>
+  <%= render 'summernote_localization' %>
 </body>

--- a/app/views/application/_summernote_localization.html.erb
+++ b/app/views/application/_summernote_localization.html.erb
@@ -1,0 +1,3 @@
+<% unless current_language.summernote_locale.blank? %>
+  <script id="summernote-locale" data-locale="<%= current_language.summernote_locale %>" src="https://cdn.jsdelivr.net/npm/summernote@<%= SummernoteRails::Rails::VERSION.split('.').take(3).join('.') %>/dist/lang/summernote-<%= current_language.summernote_locale %>.js"></script>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,5 +19,6 @@
     <%= render 'footer' %>
     <%= render 'gdpr/cookie_consent' %>
     <%= render 'bugsnag' %>
+    <%= render 'summernote_localization' %>
   </body>
 </html>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -36,5 +36,6 @@
     <%= render 'footer' %>
     <%= render 'gdpr/cookie_consent' %>
     <%= render 'bugsnag' %>
+    <%= render 'summernote_localization' %>
   </body>
 </html>

--- a/app/views/server/languages/_form.html.erb
+++ b/app/views/server/languages/_form.html.erb
@@ -3,11 +3,14 @@
   <%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
 
   <div class="row">
-    <div class="col-md-8">
+    <div class="col-md-4">
       <%= f.input :name %>
     </div>
     <div class="col-md-4">
       <%= f.input :iso_code %>
+    </div>
+    <div class="col-md-4">
+      <%= f.input :summernote_locale %>
     </div>
   </div>
 

--- a/app/views/server/languages/index.html.erb
+++ b/app/views/server/languages/index.html.erb
@@ -6,6 +6,7 @@
       <tr>
         <th><%= Language.human_attribute_name('name') %></th>
         <th><%= Language.human_attribute_name('iso_code') %></th>
+        <th><%= Language.human_attribute_name('summernote_locale') %></th>
         <th></th>
       </tr>
     </thead>
@@ -15,6 +16,7 @@
         <tr>
           <td><%= link_to language, [:server, language] %></td>
           <td><%= language.iso_code %></td>
+          <td><%= language.summernote_locale %></td>
           <td class="text-end">
             <div class="btn-group" role="group">
               <%= link_to t('edit'),

--- a/app/views/server/languages/show.html.erb
+++ b/app/views/server/languages/show.html.erb
@@ -8,7 +8,7 @@
       </div>
       <div class="table-responsive">
         <table class="<%= table_classes %>">
-          <% ['iso_code'].each do |variable| %>
+          <% ['iso_code', 'summernote_locale'].each do |variable| %>
             <tr>
               <td><%= Language.human_attribute_name(variable) %></td>
               <td class="text-end"><%= @language.public_send variable %></td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,7 @@ en:
       language:
         iso_code: Iso code
         name: Name
+        summernote_locale: Summernote localization code
       user:
         admin_theme: Admin Theme
         email: Email
@@ -268,6 +269,7 @@ en:
       language:
         iso_code: ISO 639-1 code (cf <a href="https://fr.wikipedia.org/wiki/Liste_des_codes_ISO_639-1" target="_blank">WikiPedia</a>)
         name: Name in the language (= "Français", "Deutsch", ...)
+        summernote_locale: 'Name of summernote loca (fr-FR / en-US). Check here and ensure locale is available: <a href="https://github.com/summernote/summernote/tree/develop/src/lang" target="_blank">summernote repo</a>'
       user:
         mobile_phone: "International format (+XX). This number remains private. By filling this field, you accept to receive your two-factor authentication codes via SMS."
     include_blanks:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,7 +43,7 @@ en:
       language:
         iso_code: Iso code
         name: Name
-        summernote_locale: Summernote localization code
+        summernote_locale: Summernote locale code
       user:
         admin_theme: Admin Theme
         email: Email
@@ -269,7 +269,7 @@ en:
       language:
         iso_code: ISO 639-1 code (cf <a href="https://fr.wikipedia.org/wiki/Liste_des_codes_ISO_639-1" target="_blank">WikiPedia</a>)
         name: Name in the language (= "Français", "Deutsch", ...)
-        summernote_locale: 'Name of summernote loca (fr-FR / en-US). Check here and ensure locale is available: <a href="https://github.com/summernote/summernote/tree/develop/src/lang" target="_blank">summernote repo</a>'
+        summernote_locale: 'Name of summernote locale (fr-FR / en-US). Check here and ensure locale is available: <a href="https://github.com/summernote/summernote/tree/develop/src/lang" target="_blank">summernote repo</a>'
       user:
         mobile_phone: "International format (+XX). This number remains private. By filling this field, you accept to receive your two-factor authentication codes via SMS."
     include_blanks:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -43,7 +43,7 @@ fr:
       language:
         iso_code: Code Iso
         name: Nom
-        summernote_locale: Nom de la loca Summernote
+        summernote_locale: Nom de la locale Summernote
       user:
         admin_theme: Thème de l'administration
         email: Email
@@ -269,7 +269,7 @@ fr:
       language:
         iso_code: Code ISO 639-1 (cf <a href="https://fr.wikipedia.org/wiki/Liste_des_codes_ISO_639-1" target="_blank">WikiPedia</a>)
         name: Nom dans la langue (= "Français", "Deutsch", ...)
-        summernote_locale: 'Nom de la loca de summernote (fr-FR / en-US). Vérifier ici que la locale est disponible : <a href="https://github.com/summernote/summernote/tree/develop/src/lang" target="_blank">repo summernote</a>'
+        summernote_locale: 'Nom de la locale de summernote (fr-FR / en-US). Vérifier ici que la locale est disponible : <a href="https://github.com/summernote/summernote/tree/develop/src/lang" target="_blank">repo summernote</a>'
       user:
         mobile_phone: "Format international (+XX). Ce numéro reste privé. En renseignant ce champ, vous acceptez de recevoir vos codes de double authentification par SMS."
     include_blanks:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -43,6 +43,7 @@ fr:
       language:
         iso_code: Code Iso
         name: Nom
+        summernote_locale: Nom de la loca Summernote
       user:
         admin_theme: Thème de l'administration
         email: Email
@@ -268,6 +269,7 @@ fr:
       language:
         iso_code: Code ISO 639-1 (cf <a href="https://fr.wikipedia.org/wiki/Liste_des_codes_ISO_639-1" target="_blank">WikiPedia</a>)
         name: Nom dans la langue (= "Français", "Deutsch", ...)
+        summernote_locale: 'Nom de la loca de summernote (fr-FR / en-US). Vérifier ici que la locale est disponible : <a href="https://github.com/summernote/summernote/tree/develop/src/lang" target="_blank">repo summernote</a>'
       user:
         mobile_phone: "Format international (+XX). Ce numéro reste privé. En renseignant ce champ, vous acceptez de recevoir vos codes de double authentification par SMS."
     include_blanks:

--- a/db/migrate/20230112151136_add_summernote_locale_in_languages.rb
+++ b/db/migrate/20230112151136_add_summernote_locale_in_languages.rb
@@ -1,0 +1,5 @@
+class AddSummernoteLocaleInLanguages < ActiveRecord::Migration[7.0]
+  def change
+    add_column :languages, :summernote_locale, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_11_083139) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_12_151136) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -562,6 +562,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_11_083139) do
     t.string "iso_code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "summernote_locale"
   end
 
   create_table "research_journal_papers", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|

--- a/test/fixtures/languages.yml
+++ b/test/fixtures/languages.yml
@@ -2,11 +2,12 @@
 #
 # Table name: languages
 #
-#  id         :uuid             not null, primary key
-#  iso_code   :string
-#  name       :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id                :uuid             not null, primary key
+#  iso_code          :string
+#  name              :string
+#  summernote_locale :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
 #
 en:
   name: English


### PR DESCRIPTION
close #698 

Malheureusement Summernote utilise des localisations avec des locales complètes ('fr-FR', 'en-US') alors que dans Osuny nous avons juste des iso ('fr', 'en').
Pour faire le matching j'ajoute un champ dans la gestion des languages.
Ensuite on ajoute en fin de layout le chargement du fichier de locas summernote approprié.
Enfin on modifie les instanciations de summernote pour ajouter la prise en compte de la lang.