### PR TITLE
Correction du lien vers un about (STI) dans le show d'un item de menu

### DIFF
--- a/app/views/admin/communication/websites/menus/items/show.html.erb
+++ b/app/views/admin/communication/websites/menus/items/show.html.erb
@@ -28,7 +28,7 @@
             <p><%= link_to @item.url, @item.url, target: '_blank' unless @item.url.blank? %></p>
           <% elsif @item.has_about? %>
             <h3 class="h5"><%= Communication::Website::Menu::Item.human_attribute_name('about') %></h3>
-            <p><%= link_to_if can?(:read, @item.about), @item.about, [:admin, @item.about] %></p>
+            <p><%= link_to_if can?(:read, @item.about), @item.about, [:admin, @item.about.becomes(@item.about.class.base_class)] %></p>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
On utilise la méthode [`ActiveRecord::Base#becomes`](https://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-becomes) pour convertir les objets STI en leur parent. Les non-STI ne sont pas impactés car le `base_class` sera la même classe
