### PR TITLE
Correction de la méthode url des posts

### DIFF
--- a/app/models/communication/website/post.rb
+++ b/app/models/communication/website/post.rb
@@ -138,7 +138,7 @@ class Communication::Website::Post < ApplicationRecord
     return if website.url.blank?
     return if website.special_page(Communication::Website::Page::CommunicationPost)&.path.blank?
     return if current_permalink_in_website(website).blank?
-    Static.clean_path "#{website.url}#{current_permalink_in_website(website).path}"
+    "#{Static.remove_trailing_slash website.url}#{Static.clean_path current_permalink_in_website(website).path}"
   end
 
   def to_s


### PR DESCRIPTION
En se basant sur la méthode url des pages, à savoir, `Static.clean_path` sur le path du permalink, et `Static.remove_trailing_slash` sur l'URL du website