### PR TITLE
Deuxième vague de tests

### DIFF
--- a/app/views/server/blocks/show.html.erb
+++ b/app/views/server/blocks/show.html.erb
@@ -38,7 +38,7 @@
 
 <% content_for :action_bar_right do %>
   <%= link_to t('resave'),
-              server_resave_block_path(@template),
+              resave_server_block_path(@template),
               method: :post,
               class: button_classes %>
 <% end %>

--- a/config/routes/server.rb
+++ b/config/routes/server.rb
@@ -2,12 +2,10 @@ namespace :server do
   resources :universities
   resources :languages
   resources :websites, only: :index do
-    member do
-      post :refresh
-    end
+    post :refresh, on: :member
   end
-  get 'blocks' => 'blocks#index', as: :blocks
-  get 'blocks/:id' => 'blocks#show', as: :block
-  post 'blocks/:id' => 'blocks#resave', as: :resave_block
+  resources :blocks, only: [:index, :show] do
+    post :resave, on: :member
+  end
   root to: 'dashboard#index'
 end

--- a/test/controllers/extranet/home_controller_test.rb
+++ b/test/controllers/extranet/home_controller_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class Extranet::HomeControllerTest < ActionDispatch::IntegrationTest
   def test_index_unknown_context
+    host! "example.com"
     get(root_path)
     assert_response(:forbidden)
   end

--- a/test/controllers/extranet/home_controller_test.rb
+++ b/test/controllers/extranet/home_controller_test.rb
@@ -8,13 +8,13 @@ class Extranet::HomeControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_index_unauthenticated
-    host! "extranet.osuny.test"
+    host! default_extranet.host
     get(root_path)
     assert_redirected_to(new_user_session_path)
   end
 
   def test_index
-    host! "extranet.osuny.test"
+    host! default_extranet.host
     sign_in_with_2fa(alumnus)
     get(root_path)
     assert_response(:success)

--- a/test/controllers/server/blocks_controller_test.rb
+++ b/test/controllers/server/blocks_controller_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class Server::BlocksControllerTest < ActionDispatch::IntegrationTest
+  include ServerSetup
+
+  def test_index
+    get server_blocks_path
+    assert_response(:success)
+  end
+
+  def test_show
+    get(server_block_path("chapter"))
+    assert_response(:success)
+  end
+
+  def test_resave
+    post(resave_server_block_path("chapter"))
+    assert_redirected_to(server_block_path("chapter"))
+  end
+end

--- a/test/controllers/server/dashboard_controller_test.rb
+++ b/test/controllers/server/dashboard_controller_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class Server::DashboardControllerTest < ActionDispatch::IntegrationTest
+  include ServerSetup
+
+  def test_index
+    get server_root_path
+    assert_response(:success)
+  end
+end

--- a/test/controllers/server/languages_controller_test.rb
+++ b/test/controllers/server/languages_controller_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+
+class Server::LanguagesControllerTest < ActionDispatch::IntegrationTest
+  include ServerSetup
+
+  def test_index
+    get server_languages_path
+    assert_response(:success)
+  end
+
+  def test_show
+    get server_language_path(languages(:fr))
+    assert_response(:success)
+  end
+
+  def test_new
+    get new_server_language_path
+    assert_response(:success)
+  end
+
+  def test_edit
+    get edit_server_language_path(languages(:fr))
+    assert_response(:success)
+  end
+
+  def test_create
+    assert_difference("Language.count") do
+      post server_languages_path, params: {
+        language: {
+          name: "Español",
+          iso_code: "es"
+        }
+      }
+      language = Language.find_by(iso_code: "es")
+      assert_redirected_to(server_language_path(language))
+    end
+  end
+
+  def test_create_invalid
+    assert_no_difference("Language.count") do
+      post server_languages_path, params: {
+        language: {
+          name: "Français",
+          iso_code: "fr"
+        }
+      }
+      assert_response(:unprocessable_entity)
+    end
+  end
+
+  def test_update
+    language = languages(:fr)
+    assert(language.summernote_locale.blank?)
+    patch server_language_path(language), params: { language: { summernote_locale: "fr-FR" } }
+    assert_redirected_to(server_language_path(language))
+    assert_equal "fr-FR", language.reload.summernote_locale
+  end
+
+  def test_update_invalid
+    language = languages(:fr)
+    patch server_language_path(language), params: { language: { iso_code: "" } }
+    assert_response(:unprocessable_entity)
+  end
+
+  def test_destroy
+    assert_difference("Language.count", -1) do
+      delete server_language_path(languages(:it))
+      assert_redirected_to(server_languages_path)
+    end
+  end
+end

--- a/test/controllers/server/universities_controller_test.rb
+++ b/test/controllers/server/universities_controller_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+
+class Server::UniversitiesControllerTest < ActionDispatch::IntegrationTest
+  include ServerSetup
+
+  def test_index
+    get server_universities_path
+    assert_response(:success)
+  end
+
+  def test_show
+    get server_university_path(universities(:default_university))
+    assert_response(:success)
+  end
+
+  def test_new
+    get new_server_university_path
+    assert_response(:success)
+  end
+
+  def test_edit
+    get edit_server_university_path(universities(:default_university))
+    assert_response(:success)
+  end
+
+  def test_create
+    assert_difference("University.count") do
+      post server_universities_path, params: {
+        university: {
+          name: "Nouvelle université",
+          identifier: "my-second-university",
+          sms_sender_name: "unitest2"
+        }
+      }
+      university = University.find_by(identifier: "my-second-university")
+      assert_redirected_to(server_university_path(university))
+    end
+  end
+
+  def test_create_invalid
+    assert_no_difference("University.count") do
+      post server_universities_path, params: {
+        university: {
+          name: "Nouvelle université",
+          sms_sender_name: "unitest2"
+        }
+      }
+      assert_response(:unprocessable_entity)
+    end
+  end
+
+  def test_update
+    university = universities(:default_university)
+    assert_equal "Université de test", university.name
+    patch server_university_path(university), params: { university: { name: "Mon université" } }
+    assert_redirected_to(server_university_path(university))
+    assert_equal "Mon université", university.reload.name
+  end
+
+  def test_update_invalid
+    university = universities(:default_university)
+    patch server_university_path(university), params: { university: { identifier: "" } }
+    assert_response(:unprocessable_entity)
+  end
+
+  def test_destroy
+    assert_difference("University.count", -1) do
+      # TODO: Replace by default university with correct dependent: :destroy associations
+      delete server_university_path(universities(:stale_university))
+      assert_redirected_to(server_universities_path)
+    end
+  end
+end

--- a/test/controllers/server/websites_controller_test.rb
+++ b/test/controllers/server/websites_controller_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class Server::WebsitesControllerTest < ActionDispatch::IntegrationTest
+  include ServerSetup
+
+  def test_index
+    get server_websites_path
+    assert_response(:success)
+  end
+
+  def test_refresh
+    post(refresh_server_website_path(communication_websites(:website_with_github)))
+    assert_redirected_to(server_websites_path)
+  end
+end

--- a/test/fixtures/languages.yml
+++ b/test/fixtures/languages.yml
@@ -16,3 +16,7 @@ en:
 fr:
   name: Français
   iso_code: fr
+
+it:
+  name: Italiano
+  iso_code: it

--- a/test/fixtures/universities.yml
+++ b/test/fixtures/universities.yml
@@ -29,3 +29,9 @@
 default_university:
   name: Université de test
   identifier: my-university
+  sms_sender_name: "unitest"
+
+stale_university:
+  name: Université obsolète
+  identifier: stale-university
+  sms_sender_name: "unistale"

--- a/test/support/extranet_setup.rb
+++ b/test/support/extranet_setup.rb
@@ -1,6 +1,6 @@
 module ExtranetSetup
   def setup
-    host! "extranet.osuny.test"
+    host! default_extranet.host
     sign_in_with_2fa(alumnus)
   end
 end

--- a/test/support/server_setup.rb
+++ b/test/support/server_setup.rb
@@ -1,0 +1,5 @@
+module ServerSetup
+  def setup
+    sign_in_with_2fa(server_admin)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,7 +15,11 @@ class ActiveSupport::TestCase
 
   setup do
     ENV.update(ENV.to_h.merge('APPLICATION_ENV' => 'test'))
-    host! "my-university#{University.test_domain}"
+    try(:host!, default_university.host)
+  end
+
+  def default_university
+    @default_university ||= universities(:default_university)
   end
 
   def alumnus

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,6 +22,10 @@ class ActiveSupport::TestCase
     @default_university ||= universities(:default_university)
   end
 
+  def default_extranet
+    @default_extranet ||= communication_extranets(:default_extranet)
+  end
+
   def alumnus
     @alumnus ||= users(:alumnus)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,7 @@ class ActiveSupport::TestCase
 
   setup do
     ENV.update(ENV.to_h.merge('APPLICATION_ENV' => 'test'))
+    host! "my-university#{University.test_domain}"
   end
 
   def alumnus


### PR DESCRIPTION
Cette suite de tests s'occupe de la partie `server`.

A noter qu'il faudra changer le test de suppression d'université par la fixture d'université par défaut afin de supprimer les associations en cascade.