### PR TITLE
Remplissage automatique du menu légal

### DIFF
--- a/app/models/communication/website.rb
+++ b/app/models/communication/website.rb
@@ -43,9 +43,9 @@ class Communication::Website < ApplicationRecord
   include WithGit
   include WithGitRepository
   include WithImport
-  include WithMenus
   include WithProgramCategories
   include WithSpecialPages
+  include WithMenus # Menus must be created after special pages, so we can fill legal menu
   include WithStyle
   include WithTheme
 

--- a/app/models/communication/website/with_menus.rb
+++ b/app/models/communication/website/with_menus.rb
@@ -7,7 +7,7 @@ module Communication::Website::WithMenus
                 foreign_key: :communication_website_id,
                 dependent: :destroy
 
-    after_create :initialize_menus
+    after_save :initialize_menus
   end
 
   def menu_item_kinds
@@ -65,14 +65,34 @@ module Communication::Website::WithMenus
 
   def initialize_menus
     create_menu 'primary'
-    create_menu 'legal'
     create_menu 'social'
+    menu = create_menu 'legal'
+    fill_legal_menu menu
+  end
+
+  def fill_legal_menu(menu)
+    return if menu.items.any?
+    [
+      Communication::Website::Page::LegalTerm,
+      Communication::Website::Page::PrivacyPolicy,
+      Communication::Website::Page::Accessibility,
+      Communication::Website::Page::Sitemap
+    ].each do |page_class|
+      page = special_page(page_class)
+      menu.items.where( kind: 'page', 
+                        about: page,
+                        university: university,
+                        website: self)
+                .first_or_create do |item|
+        item.title = page.title
+      end
+    end
   end
 
   def create_menu(identifier)
     title = Communication::Website::Menu.human_attribute_name(identifier)
-    menus.create  title: title,
-                  identifier: identifier,
-                  university: university
+    menus.where(identifier: identifier, university: university).first_or_create do |menu|
+      menu.title = title
+    end
   end
 end

--- a/app/models/communication/website/with_menus.rb
+++ b/app/models/communication/website/with_menus.rb
@@ -64,9 +64,9 @@ module Communication::Website::WithMenus
   protected
 
   def initialize_menus
-    create_menu 'primary'
-    create_menu 'social'
-    menu = create_menu 'legal'
+    find_or_create_menu 'primary'
+    find_or_create_menu 'social'
+    menu = find_or_create_menu 'legal'
     fill_legal_menu menu
   end
 
@@ -89,7 +89,7 @@ module Communication::Website::WithMenus
     end
   end
 
-  def create_menu(identifier)
+  def find_or_create_menu(identifier)
     title = Communication::Website::Menu.human_attribute_name(identifier)
     menus.where(identifier: identifier, university: university).first_or_create do |menu|
       menu.title = title


### PR DESCRIPTION
Si le menu est vide, à chaque enregistrement du site il est reconstitué avec les pages mentions légales, politique de confidentialité, a11y et plan du site. 