### PR TITLE
Correction des maps de l'extranet

### DIFF
--- a/app/assets/javascripts/extranet.js
+++ b/app/assets/javascripts/extranet.js
@@ -11,7 +11,6 @@
 //= require simple_form_bs5_file_input
 //= require summernote/summernote-bs5
 //= require gdpr/cookie_consent
-//= require leaflet
 //= require autocomplete-rails
 //= require_tree ./application/plugins
 //= require_tree ./extranet

--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -1,0 +1,1 @@
+//= require leaflet

--- a/app/views/extranet/contacts/organizations/show.html.erb
+++ b/app/views/extranet/contacts/organizations/show.html.erb
@@ -64,6 +64,8 @@
         </dd>
       <% end %>
       <% if @organization.geolocated? %>
+        <%# Include map.js before call Leaflet (map helper) %>
+        <%= javascript_include_tag 'map' %>
         <dt><%= University::Organization.human_attribute_name(:map) %></dt>
         <dl><%= map(
               center: {


### PR DESCRIPTION
Pour que Leaflet soit présent avant l'initialisation de la map, on l'importe via un autre fichier JS, de la même manière qu'on importe Vue quand on en a besoin.