### PR TITLE
Correction d'une recherche vide sur Pexels

### DIFF
--- a/app/views/admin/communication/photo_imports/pexels.json.jbuilder
+++ b/app/views/admin/communication/photo_imports/pexels.json.jbuilder
@@ -6,4 +6,4 @@ json.results @search.photos do |photo|
   json.credit "Photo by <a href=\"#{photo.user.url}\">#{photo.user.name}</a> on <a href=\"https://www.pexels.com\">Pexels</a>"
   json.thumb photo.src['large']
   json.preview photo.src['large2x']
-end
+end if @search


### PR DESCRIPTION
Fix #804

Appeler @search.photos sur un tableau vide crashe côté Pexels