### PR TITLE
Ajustements headings et blocs

### DIFF
--- a/app/assets/javascripts/admin/commons/content_editor.js
+++ b/app/assets/javascripts/admin/commons/content_editor.js
@@ -68,11 +68,12 @@ window.osuny.contentEditor = {
     onSortableMove: function (event) {
         'use strict';
         var draggedKind = event.dragged.dataset.kind,
-            relatedKind = event.related.dataset.kind;
+            relatedKind = event.related.dataset.kind,
+            firstHeading = this.sortableRootContainer.querySelector('.js-content-editor-element[data-kind="heading"]');
 
         if (draggedKind === 'block') {
             // Prevent dragging a block after a heading, instead of inside
-            return relatedKind !== 'heading' || !event.willInsertAfter;
+            return relatedKind !== 'heading' || (!event.willInsertAfter && event.related === firstHeading);
         }
         return true;
     },

--- a/app/assets/javascripts/admin/commons/content_editor.js
+++ b/app/assets/javascripts/admin/commons/content_editor.js
@@ -73,7 +73,7 @@ window.osuny.contentEditor = {
 
         if (draggedKind === 'block') {
             // Prevent dragging a block after a heading, instead of inside
-            return relatedKind !== 'heading' || (!event.willInsertAfter && event.related === firstHeading);
+            return relatedKind !== 'heading' || !event.willInsertAfter && event.related === firstHeading;
         }
         return true;
     },

--- a/app/models/communication/block/heading.rb
+++ b/app/models/communication/block/heading.rb
@@ -39,7 +39,8 @@ class Communication::Block::Heading < ApplicationRecord
               optional: true
   has_many    :children,
               class_name: 'Communication::Block::Heading',
-              foreign_key: :parent_id
+              foreign_key: :parent_id,
+              dependent: :nullify
   has_many    :blocks,
               dependent: :nullify
 


### PR DESCRIPTION
- Dependent nullify sur les headings enfants
- fix #1093 : les blocs ne sont glissables que dans des headings ou avant le premier heading