### PR TITLE
Correction des tâches nocturnes

### DIFF
--- a/app/jobs/research/hal/update_job.rb
+++ b/app/jobs/research/hal/update_job.rb
@@ -1,0 +1,7 @@
+class Research::Hal::UpdateJob < ApplicationJob
+  queue_as :low_priority
+
+  def perform
+    Research::Hal.update_from_api!
+  end
+end

--- a/app/models/communication/website/with_connected_objects.rb
+++ b/app/models/communication/website/with_connected_objects.rb
@@ -15,6 +15,8 @@ module Communication::Website::WithConnectedObjects
     connect(about, self) if about.present?
     destroy_obsolete_connections
     # In the same job
+    create_missing_special_pages
+    initialize_menus
     sync_with_git_without_delay
     destroy_obsolete_git_files_without_delay
   end

--- a/app/models/communication/website/with_connected_objects.rb
+++ b/app/models/communication/website/with_connected_objects.rb
@@ -7,7 +7,7 @@ module Communication::Website::WithConnectedObjects
     after_save :connect_about, if: :saved_change_to_about_id?
   end
 
-  def rebuild_connections_and_git_files
+  def clean_and_rebuild
     pages.find_each(&:connect_dependencies)
     posts.find_each(&:connect_dependencies)
     categories.find_each(&:connect_dependencies)
@@ -20,7 +20,7 @@ module Communication::Website::WithConnectedObjects
     sync_with_git_without_delay
     destroy_obsolete_git_files_without_delay
   end
-  handle_asynchronously :rebuild_connections_and_git_files, queue: :low_priority
+  handle_asynchronously :clean_and_rebuild, queue: :low_priority
 
   # Appelé
   # - par un objet avec des connexions lorsqu'il est destroyed

--- a/app/models/communication/website/with_menus.rb
+++ b/app/models/communication/website/with_menus.rb
@@ -61,8 +61,6 @@ module Communication::Website::WithMenus
     has_research_papers?
   end
 
-  protected
-
   def initialize_menus
     find_or_create_menu 'primary'
     find_or_create_menu 'social'
@@ -71,6 +69,8 @@ module Communication::Website::WithMenus
       fill_legal_menu(menu)
     end
   end
+
+  protected
 
   def find_or_create_menu(identifier)
     menu = menus.where(identifier: identifier, university: university, language: default_language).first_or_initialize do |menu|

--- a/app/models/communication/website/with_special_pages.rb
+++ b/app/models/communication/website/with_special_pages.rb
@@ -7,12 +7,17 @@ module Communication::Website::WithSpecialPages
   end
 
   def special_page(type, language: default_language)
-    find_special_page(type, language) || translate_special_page(type, language)
+    page = find_special_page(type, language)
+    # If not found, create if default language, else translate
+    page ||= language == default_language ? create_special_page(type, language)
+                                          : translate_special_page(type, language)
+    page
   end
 
   def create_missing_special_pages
     Communication::Website::Page::TYPES.each do |page_class|
-      page = page_class.where(website: self, university: university, language_id: default_language_id).first_or_initialize # Special pages have an before_validation (:on_create) callback to preset title, slug, ...
+      # Special pages have an before_validation (:on_create) callback to preset title, slug, ...
+      page = page_class.where(website: self, university: university, language_id: default_language_id).first_or_initialize
       next if page.persisted? # No resave
       next unless page.is_necessary_for_website? # No useless pages
       page.save_and_sync
@@ -25,10 +30,15 @@ module Communication::Website::WithSpecialPages
     pages.where(type: type.to_s, language_id: language.id).first
   end
 
+  def create_special_page(type, language)
+    # Special pages have an before_validation (:on_create) callback to preset title, slug, ...
+    page = pages.where(type: type.to_s, language_id: language.id, university_id: university_id).first_or_initialize
+    page.save_and_sync
+  end
+
   def translate_special_page(type, language)
     # Not found for given language, we create it from the page in default_language
-    original_special_page = pages.where(type: type.to_s, language_id: default_language_id).first
-    return unless original_special_page.present?
+    original_special_page = special_page(type, language: default_language)
     translated_special_page = original_special_page.translate!(language)
     # When we translate a new post, it will generate the permalink by looking for the posts special page
     # It will try to find it, or translate it if not found

--- a/app/models/communication/website/with_special_pages.rb
+++ b/app/models/communication/website/with_special_pages.rb
@@ -9,7 +9,7 @@ module Communication::Website::WithSpecialPages
   def special_page(type, language: default_language)
     page = find_special_page(type, language)
     # If not found, create if default language, else translate
-    page ||= language == default_language ? create_special_page(type, language)
+    page ||= language == default_language ? create_default_special_page(type)
                                           : translate_special_page(type, language)
     page
   end
@@ -30,9 +30,9 @@ module Communication::Website::WithSpecialPages
     pages.where(type: type.to_s, language_id: language.id).first
   end
 
-  def create_special_page(type, language)
+  def create_default_special_page(type)
     # Special pages have a before_validation (:on_create) callback to preset title, slug, ...
-    page = pages.where(type: type.to_s, language_id: language.id, university_id: university_id).first_or_initialize
+    page = pages.where(type: type.to_s, language_id: default_language_id, university_id: university_id).first_or_initialize
     page.save_and_sync
   end
 

--- a/app/models/communication/website/with_special_pages.rb
+++ b/app/models/communication/website/with_special_pages.rb
@@ -16,7 +16,7 @@ module Communication::Website::WithSpecialPages
 
   def create_missing_special_pages
     Communication::Website::Page::TYPES.each do |page_class|
-      # Special pages have an before_validation (:on_create) callback to preset title, slug, ...
+      # Special pages have a before_validation (:on_create) callback to preset title, slug, ...
       page = page_class.where(website: self, university: university, language_id: default_language_id).first_or_initialize
       next if page.persisted? # No resave
       next unless page.is_necessary_for_website? # No useless pages
@@ -31,7 +31,7 @@ module Communication::Website::WithSpecialPages
   end
 
   def create_special_page(type, language)
-    # Special pages have an before_validation (:on_create) callback to preset title, slug, ...
+    # Special pages have a before_validation (:on_create) callback to preset title, slug, ...
     page = pages.where(type: type.to_s, language_id: language.id, university_id: university_id).first_or_initialize
     page.save_and_sync
   end

--- a/cron.json
+++ b/cron.json
@@ -4,7 +4,7 @@
       "command": "0 1 * * * rails auto:update_publications_from_hal"
     },
     {
-      "command": "0 3 * * * rails auto:save_and_sync_websites"
+      "command": "0 3 * * * rails auto:clean_and_rebuild_websites"
     }
   ]
 }

--- a/lib/tasks/auto.rake
+++ b/lib/tasks/auto.rake
@@ -2,13 +2,15 @@ namespace :auto do
 
   desc 'Update publications from HAL for all researchers'
   task update_hal: :environment do
+    # Research::Hal.update_from_api! is synchronous, we use a job for that
     Research::Hal::UpdateJob.perform_later
   end
 
-  desc 'Resave every website to enable publications in the future'
-  task save_and_sync_websites: :environment do
+  desc 'Clean and rebuild every website to enable publications in the future'
+  task clean_and_rebuild_websites: :environment do
     Communication::Website.find_each do |website|
-      website.rebuild_connections_and_git_files
+      # Communication::Website#clean_and_rebuild is asynchronous, no need for a intermediate job
+      website.clean_and_rebuild
     end
   end
 

--- a/lib/tasks/auto.rake
+++ b/lib/tasks/auto.rake
@@ -2,7 +2,7 @@ namespace :auto do
 
   desc 'Update publications from HAL for all researchers'
   task update_hal: :environment do
-    Research::Hal.update_from_api!
+    Research::Hal::UpdateJob.perform_later
   end
 
   desc 'Resave every website to enable publications in the future'


### PR DESCRIPTION
- La mise à jour HAL se fait en async via `Research::Hal::UpdateJob`
- La tâche nocturne des sites gère les menus et pages spéciales manquantes
- La méthode `Communication::Website#special_page(type, language:)` gère désormais la création de la page à son appel