### PR TITLE
Sécurité : Gestion des blocs embed liés à des sources indirectes

### DIFF
--- a/app/models/communication/website/with_associated_objects.rb
+++ b/app/models/communication/website/with_associated_objects.rb
@@ -21,12 +21,28 @@ module Communication::Website::WithAssociatedObjects
     has_many    :permalinks,
                 class_name: "Communication::Website::Permalink",
                 dependent: :destroy
-                
+
     has_many    :communication_blocks,
                 class_name: "Communication::Block",
                 foreign_key: :communication_website_id
     alias       :blocks :communication_blocks
 
+  end
+
+  def blocks_from_education
+    Communication::Block.where(about: education_programs).or(
+      Communication::Block.where(about: education_diplomas)
+    )
+  end
+
+  def blocks_from_research
+    Communication::Block.where(about: research_papers)
+  end
+
+  def blocks_from_university
+    Communication::Block.where(about: connected_people).or(
+      Communication::Block.where(about: connected_organizations)
+    )
   end
 
   def education_diplomas

--- a/app/models/communication/website/with_security.rb
+++ b/app/models/communication/website/with_security.rb
@@ -5,7 +5,10 @@ module Communication::Website::WithSecurity
     list = external_domains_default
     list.concat external_domains_plausible
     list.concat external_domains_from_blocks_video
-    list.concat external_domains_from_blocks_embed
+    list.concat external_domains_from_blocks_embed(blocks)
+    list.concat external_domains_from_blocks_embed(blocks_from_education)
+    list.concat external_domains_from_blocks_embed(blocks_from_research)
+    list.concat external_domains_from_blocks_embed(blocks_from_university)
     list.uniq.compact
   end
 
@@ -34,14 +37,14 @@ module Communication::Website::WithSecurity
     list
   end
 
-  def external_domains_from_blocks_embed
+  def external_domains_from_blocks_embed(blocks)
     list = []
-    blocks.where(template_kind: :embed).each do |block|
+    blocks.where(template_kind: :embed).published.each do |block|
       code = block.template.code
       # https://stackoverflow.com/questions/25095176/extracting-all-urls-from-a-page-using-ruby
       code.scan(/[[:lower:]]+:\/\/[^\s"]+/).each do |url|
         url = CGI.unescapeHTML(url)
-        url =  ActionController::Base.helpers.strip_tags(url)
+        url = ActionController::Base.helpers.strip_tags(url)
         url = URI::Parser.new.escape(url)
         host = URI.parse(url).host
         list << host


### PR DESCRIPTION
Pour la gestion du CSP, on gérait les blocs embed des objets directs d'un site (category, post, page) mais pas des objets indirects (program, diploma, paper, person, organization)