### PR TITLE
Path incorrect dans le bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -22,7 +22,7 @@ FileUtils.chdir APP_ROOT do
 
   puts "\n== Copying sample files =="
   unless File.exist?("config/application.yml")
-    FileUtils.cp "config/application.yml.sample", "config/application.yml"
+    FileUtils.cp "config/application.sample.yml", "config/application.yml"
   end
 
   puts "\n== Preparing database =="


### PR DESCRIPTION
Bonjour aux membres de Noesya :)

Lorsque j'ai setup Osuny j'ai remarqué que le bin/setup contenait une erreur de path lors de la copie du sample de config.
Je propose ici un tout petit fix qui m'a permis de continuer l'installation.

Bonne soirée ou bon matin,
J'espère pouvoir contribuer plus amplement par la suite !