### PR TITLE
L'hébergement Deuxfleurs est en staging tant qu'on ne passe pas le site en production

### DIFF
--- a/app/views/admin/communication/websites/configs/deuxfleurs_workflow/static.html.erb
+++ b/app/views/admin/communication/websites/configs/deuxfleurs_workflow/static.html.erb
@@ -31,7 +31,7 @@ jobs:
         extended: true
 
     - name: Compilation du site
-      run: yarn osuny build
+      run: <% unless @website.in_production %>HUGO_ENVIRONMENT=staging <% end %>yarn osuny build
 
     - name: Déploiement Garage
       run: hugo deploy --force --maxDeletes -1


### PR DESCRIPTION
Ça permet d'avoir les helpers Ctrl+W et Ctrl++G 