### PR TITLE
Niveau de titre du bloc

### DIFF
--- a/app/models/communication/block.rb
+++ b/app/models/communication/block.rb
@@ -39,6 +39,7 @@ class Communication::Block < ApplicationRecord
 
   IMAGE_MAX_SIZE = 5.megabytes
   FILE_MAX_SIZE = 100.megabytes
+  DEFAULT_HEADING_LEVEL = 2 # h1 is the page title
 
   belongs_to :about, polymorphic: true
   belongs_to :heading, optional: true
@@ -150,6 +151,11 @@ class Communication::Block < ApplicationRecord
 
   def full_text
     template.full_text
+  end
+
+  def heading_level
+    heading.present?  ? heading.level + 1
+                      : DEFAULT_HEADING_LEVEL
   end
 
   def to_s

--- a/app/views/admin/communication/blocks/_static.html.erb
+++ b/app/views/admin/communication/blocks/_static.html.erb
@@ -7,6 +7,7 @@ should_render_data = block.data && block.data.present?
     title: >-
       <%= prepare_text_for_static block.title %>
     position: <%= block.position %>
+    heading_level: <%= block.heading_level %>
     data:
 <%= render  template_path, 
             block: block, 


### PR DESCRIPTION
Fix #1376

```
  - kind: block
    template: key_figures
    title: >-
      Bloc key figure
    position: 0
    heading_level: 3
```

Dans ce cas, il faut que les titres à l'intérieur du bloc soient des h3. 
Cela veut dire que le bloc est lui-même sous un heading h2.