### PR TITLE
Fix static du bloc Licence

### DIFF
--- a/app/views/admin/communication/blocks/templates/license/_static.html.erb
+++ b/app/views/admin/communication/blocks/templates/license/_static.html.erb
@@ -1,7 +1,7 @@
 <%
 cc = Licenses::CreativeCommons.create_from_block(block)
 %>
-<%= block_component_static block, :type -%>
+<%= block_component_static block, :type %>
       creative_commons:
         attribution: <%= block.template.creative_commons_attribution %>
         commercial_use: <%= block.template.creative_commons_commercial_use %>


### PR DESCRIPTION
Manque un retour à la ligne à cause de `-%>`