### PR TITLE
Ajout de CSP

### DIFF
--- a/app/assets/javascripts/leaflet.js
+++ b/app/assets/javascripts/leaflet.js
@@ -1,0 +1,1 @@
+//= require leaflet/dist/leaflet.js

--- a/app/assets/stylesheets/admin/commons/sidebar.sass
+++ b/app/assets/stylesheets/admin/commons/sidebar.sass
@@ -1,0 +1,2 @@
+.sidebar-icon
+    min-width: 30px

--- a/app/assets/stylesheets/leaflet.sass
+++ b/app/assets/stylesheets/leaflet.sass
@@ -1,0 +1,1 @@
+@import 'leaflet/dist/leaflet'

--- a/app/views/admin/communication/blocks/edit.html.erb
+++ b/app/views/admin/communication/blocks/edit.html.erb
@@ -43,7 +43,7 @@
 <%# Include vue.js before call Vue.createApp %>
 <%= javascript_include_tag 'vue' %>
 
-<script nonce=<%= request.content_security_policy_nonce %>>
+<script nonce="<%= request.content_security_policy_nonce %>">
   var app = Vue.createApp({
     components: {
       draggable: VueDraggableNext.VueDraggableNext,

--- a/app/views/admin/communication/blocks/edit.html.erb
+++ b/app/views/admin/communication/blocks/edit.html.erb
@@ -43,7 +43,7 @@
 <%# Include vue.js before call Vue.createApp %>
 <%= javascript_include_tag 'vue' %>
 
-<script>
+<script nonce=<%= request.content_security_policy_nonce %>>
   var app = Vue.createApp({
     components: {
       draggable: VueDraggableNext.VueDraggableNext,

--- a/app/views/admin/communication/blocks/templates/organizations/_show.html.erb
+++ b/app/views/admin/communication/blocks/templates/organizations/_show.html.erb
@@ -25,14 +25,8 @@
       <% if block.template.layout == "grid" %>
         <div class="organizations grid">
       <% else # Map %>
+        <% content_for :leaflet_required, true %>
         <div class="map" data-marker-icon="<%= image_path 'map-marker.svg' %>">
-          <link   rel="stylesheet"
-                  href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css"
-                  integrity="sha256-kLaT2GOSpHechhsozzB+flnD+zUyjE2LlfWPgU04xyI="
-                  crossorigin=""/>
-          <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"
-                  integrity="sha256-WBkoXOwTeyKclOHuWtc+i2uENFpDZ9YPdf5Hf+D7ewM="
-                  crossorigin=""></script>
       <% end %>
         <% block.template.elements.each do |element| %>
           <article  class="organization"

--- a/app/views/admin/communication/extranets/_sidebar.html.erb
+++ b/app/views/admin/communication/extranets/_sidebar.html.erb
@@ -25,7 +25,7 @@
       %>
         <li class="mb-3">
           <a class="d-block py-1 <%= active ? 'text-black' : 'text-muted' %>" href="<%= object[:path] %>">
-            <i class="<%= object[:icon] %>" style="min-width: 30px"></i>
+            <i class="sidebar-icon <%= object[:icon] %>"></i>
             <%= object[:title].html_safe %>
           </a>
         </li>

--- a/app/views/admin/communication/photo_imports/_selector.html.erb
+++ b/app/views/admin/communication/photo_imports/_selector.html.erb
@@ -157,7 +157,7 @@ pexels_path = admin_communication_pexels_path(website_id: nil, extranet_id: nil,
 <%# Include vue.js before call Vue.createApp %>
 <%= javascript_include_tag 'vue' %>
 
-<script>
+<script nonce=<%= request.content_security_policy_nonce %>>
   var app = Vue.createApp({
     data() {
       return {

--- a/app/views/admin/communication/photo_imports/_selector.html.erb
+++ b/app/views/admin/communication/photo_imports/_selector.html.erb
@@ -157,7 +157,7 @@ pexels_path = admin_communication_pexels_path(website_id: nil, extranet_id: nil,
 <%# Include vue.js before call Vue.createApp %>
 <%= javascript_include_tag 'vue' %>
 
-<script nonce=<%= request.content_security_policy_nonce %>>
+<script nonce="<%= request.content_security_policy_nonce %>">
   var app = Vue.createApp({
     data() {
       return {

--- a/app/views/admin/communication/websites/_sidebar.html.erb
+++ b/app/views/admin/communication/websites/_sidebar.html.erb
@@ -52,7 +52,7 @@
       %>
         <li class="mb-3">
           <a class="d-block py-1 <%= active ? 'text-black' : 'text-muted' %>" href="<%= object[:path] %>">
-            <i class="<%= object[:icon] %>" style="min-width: 30px"></i>
+            <i class="sidebar-icon <%= object[:icon] %>"></i>
             <%= object[:title].html_safe %>
           </a>
         </li>

--- a/app/views/admin/layouts/application.html.erb
+++ b/app/views/admin/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <title><%= content_for?(:title) ? raw("#{yield(:title)} ∙ Osuny") : 'Osuny' %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <script nonce=<%= request.content_security_policy_nonce %>>
+    <script nonce="<%= request.content_security_policy_nonce %>">
     // Avoid opening menu on load
     </script>
     <%= stylesheet_link_tag "admin/#{current_admin_theme}", media: 'all' %>

--- a/app/views/admin/layouts/application.html.erb
+++ b/app/views/admin/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <title><%= content_for?(:title) ? raw("#{yield(:title)} ∙ Osuny") : 'Osuny' %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <script>
+    <script nonce=<%= request.content_security_policy_nonce %>>
     // Avoid opening menu on load
     </script>
     <%= stylesheet_link_tag "admin/#{current_admin_theme}", media: 'all' %>

--- a/app/views/admin/layouts/preview.html.erb
+++ b/app/views/admin/layouts/preview.html.erb
@@ -18,6 +18,10 @@
       padding-top: 0;
     }
     </style>
+    <% if content_for?(:leaflet_required) %>
+      <%= stylesheet_link_tag 'leaflet', media: 'all' %>
+      <%= javascript_include_tag 'leaflet' %>%
+    <% end %>
   </head>
   <body class="full-width">
     <header class="hero <%= 'hero--with-image hero--image-square' if yield(:image).present? %>">
@@ -40,4 +44,5 @@
     </main>
   </body>
   <script src="https://example.osuny.org/js/preview.js"></script>
+  
 </html>

--- a/app/views/admin/layouts/preview.html.erb
+++ b/app/views/admin/layouts/preview.html.erb
@@ -20,7 +20,7 @@
     </style>
     <% if content_for?(:leaflet_required) %>
       <%= stylesheet_link_tag 'leaflet', media: 'all' %>
-      <%= javascript_include_tag 'leaflet' %>%
+      <%= javascript_include_tag 'leaflet' %>
     <% end %>
   </head>
   <body class="full-width">

--- a/app/views/admin/research/journals/_sidebar.html.erb
+++ b/app/views/admin/research/journals/_sidebar.html.erb
@@ -29,7 +29,7 @@
       %>
         <li class="mb-3">
           <a class="d-block py-1 <%= active ? 'text-black' : 'text-muted' %>" href="<%= object[:path] %>">
-            <i class="<%= object[:icon] %>" style="min-width: 30px"></i>
+            <i class="sidebar-icon <%= object[:icon] %>"></i>
             <%= object[:title].html_safe %>
           </a>
         </li>

--- a/app/views/application/_bugsnag.html.erb
+++ b/app/views/application/_bugsnag.html.erb
@@ -1,6 +1,6 @@
 <% unless Rails.env.development? %>
   <script src="//d2wy8f7a9ursnm.cloudfront.net/v7/bugsnag.min.js"></script>
-  <script type="text/javascript" nonce=<%= request.content_security_policy_nonce %>>
+  <script type="text/javascript" nonce="<%= request.content_security_policy_nonce %>">
     Bugsnag.start({
       apiKey: "<%= j ENV['BUGSNAG_JAVASCRIPT_KEY'] %>",
       releaseStage: "<%= j ENV['APPLICATION_ENV'] %>"

--- a/app/views/application/_bugsnag.html.erb
+++ b/app/views/application/_bugsnag.html.erb
@@ -1,6 +1,6 @@
 <% unless Rails.env.development? %>
   <script src="//d2wy8f7a9ursnm.cloudfront.net/v7/bugsnag.min.js"></script>
-  <script type="text/javascript">
+  <script type="text/javascript" nonce=<%= request.content_security_policy_nonce %>>
     Bugsnag.start({
       apiKey: "<%= j ENV['BUGSNAG_JAVASCRIPT_KEY'] %>",
       releaseStage: "<%= j ENV['APPLICATION_ENV'] %>"

--- a/app/views/extranet/layouts/application.html.erb
+++ b/app/views/extranet/layouts/application.html.erb
@@ -2,6 +2,10 @@
 <html>
   <head>
     <%= render 'extranet/application/head' %>
+    <% if content_for?(:leaflet_required) %>
+      <%= stylesheet_link_tag 'leaflet', media: 'all' %>
+      <%= javascript_include_tag 'leaflet' %>%
+    <% end %>
   </head>
   <body class="extranet <%= body_classes %> full-width">
     <%= render 'application/notice' %>

--- a/app/views/extranet/layouts/application.html.erb
+++ b/app/views/extranet/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <%= render 'extranet/application/head' %>
     <% if content_for?(:leaflet_required) %>
       <%= stylesheet_link_tag 'leaflet', media: 'all' %>
-      <%= javascript_include_tag 'leaflet' %>%
+      <%= javascript_include_tag 'leaflet' %>
     <% end %>
   </head>
   <body class="extranet <%= body_classes %> full-width">

--- a/app/views/server/layouts/application.html.erb
+++ b/app/views/server/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <title><%= content_for?(:title) ? raw("#{yield(:title)} ∙ Osuny") : 'Osuny' %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <script>
+    <script nonce=<%= request.content_security_policy_nonce %>>
     // Avoid opening menu on load
     </script>
     <%= stylesheet_link_tag 'admin/pure', media: 'all' %>

--- a/app/views/server/layouts/application.html.erb
+++ b/app/views/server/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <title><%= content_for?(:title) ? raw("#{yield(:title)} ∙ Osuny") : 'Osuny' %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <script nonce=<%= request.content_security_policy_nonce %>>
+    <script nonce="<%= request.content_security_policy_nonce %>">
     // Avoid opening menu on load
     </script>
     <%= stylesheet_link_tag 'admin/pure', media: 'all' %>

--- a/app/views/server/universities/_sso_mapping.html.erb
+++ b/app/views/server/universities/_sso_mapping.html.erb
@@ -74,7 +74,7 @@ end
 
 </div>
 
-<script>
+<script nonce=<%= request.content_security_policy_nonce %>>
   var app = Vue.createApp({
     components: {
       draggable: VueDraggableNext.VueDraggableNext,

--- a/app/views/server/universities/_sso_mapping.html.erb
+++ b/app/views/server/universities/_sso_mapping.html.erb
@@ -74,7 +74,7 @@ end
 
 </div>
 
-<script nonce=<%= request.content_security_policy_nonce %>>
+<script nonce="<%= request.content_security_policy_nonce %>">
   var app = Vue.createApp({
     components: {
       draggable: VueDraggableNext.VueDraggableNext,

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,29 +6,21 @@
 
 Rails.application.configure do
 
-  style_urls = %w[
-  ]
-  img_urls = %w[
-  ]
-  script_urls = %w[
+  style_urls = %w()
+  img_urls = %w()
+  script_urls = %w(
     https://example.osuny.org/js/
     https://plausible.io
     https//d2wy8f7a9ursnm.cloudfront.net/v7/
-  ]
+  )
   script_urls << "https://cdn.jsdelivr.net/npm/summernote@#{SummernoteRails::Rails::VERSION.split('.').take(3).join('.')}/dist/lang/"
   
-  font_urls = %w[
-  ]
-  media_urls = %w[
-  ]
-  frame_urls = %w[
-  ]
-  child_urls = %w[
-  ]
-  connect_urls = %w[
-  ]
-  form_action_urls = %w[
-  ]
+  font_urls = %w()
+  media_urls = %w()
+  frame_urls = %w()
+  child_urls = %w()
+  connect_urls = %w()
+  form_action_urls = %w()
 
   defaults = %i[self https]
 
@@ -43,7 +35,7 @@ Rails.application.configure do
     policy.object_src  :none
     # We specify :unsafe_inline for browsers which not support nonce.
     # Unsafe eval is required for Vue scripts
-    policy.script_src  :self, :unsafe_inline, :unsafe_eval, *script_urls
+    policy.script_src  :self, :unsafe_eval, *script_urls
     policy.style_src   :self, :unsafe_inline, *style_urls
     # If you are using webpack-dev-server then specify webpack-dev-server host
     # policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,61 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+
+  style_urls = %w[
+  ]
+  img_urls = %w[
+  ]
+  script_urls = %w[
+    https://example.osuny.org/js/
+    https://plausible.io
+    https//d2wy8f7a9ursnm.cloudfront.net/v7/
+  ]
+  script_urls << "https://cdn.jsdelivr.net/npm/summernote@#{SummernoteRails::Rails::VERSION.split('.').take(3).join('.')}/dist/lang/"
+  
+  font_urls = %w[
+  ]
+  media_urls = %w[
+  ]
+  frame_urls = %w[
+  ]
+  child_urls = %w[
+  ]
+  connect_urls = %w[
+  ]
+  form_action_urls = %w[
+  ]
+
+  defaults = %i[self https]
+
+  config.content_security_policy do |policy|
+    policy.base_uri    :none
+    policy.default_src *defaults
+    policy.font_src    *defaults, :data, *font_urls
+    policy.img_src     *defaults, :data, *img_urls
+    policy.media_src   *defaults, *media_urls
+    policy.frame_src   *defaults, *frame_urls
+    policy.child_src   *defaults, *child_urls
+    policy.object_src  :none
+    # We specify :unsafe_inline for browsers which not support nonce.
+    # Unsafe eval is required for Vue scripts
+    policy.script_src  :self, :unsafe_inline, :unsafe_eval, *script_urls
+    policy.style_src   :self, :unsafe_inline, *style_urls
+    # If you are using webpack-dev-server then specify webpack-dev-server host
+    # policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+    policy.connect_src *defaults, *connect_urls
+    policy.form_action *defaults, *form_action_urls
+
+    # Specify URI for violation reports
+    # policy.report_uri "/csp-violation-report-endpoint"
+  end
+
+
+  # Generate session nonces for permitted importmap, inline scripts, and inline styles.
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_directives = %w(script-src)
+
+  # Report violations without enforcing the policy.
+  # config.content_security_policy_report_only = true
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
   enable_extension "plpgsql"
   enable_extension "unaccent"
 
-  create_table "action_text_rich_texts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "action_text_rich_texts", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
     t.string "record_type", null: false
@@ -26,7 +26,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
   end
 
-  create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "active_storage_attachments", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
     t.uuid "record_id", null: false
@@ -36,7 +36,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "active_storage_blobs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -50,13 +50,13 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["university_id"], name: "index_active_storage_blobs_on_university_id"
   end
 
-  create_table "active_storage_variant_records", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "active_storage_variant_records", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table "administration_qualiopi_criterions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "administration_qualiopi_criterions", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.integer "number"
     t.text "name"
     t.text "description"
@@ -64,7 +64,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "administration_qualiopi_indicators", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "administration_qualiopi_indicators", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "criterion_id", null: false
     t.integer "number"
     t.text "name"
@@ -95,7 +95,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["university_id"], name: "index_communication_block_headings_on_university_id"
   end
 
-  create_table "communication_blocks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_blocks", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.string "about_type"
     t.uuid "about_id"
@@ -106,8 +106,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.datetime "updated_at", null: false
     t.string "title"
     t.boolean "published", default: true
-    t.uuid "heading_id"
     t.uuid "communication_website_id"
+    t.uuid "heading_id"
     t.string "migration_identifier"
     t.index ["about_type", "about_id"], name: "index_communication_website_blocks_on_about"
     t.index ["communication_website_id"], name: "index_communication_blocks_on_communication_website_id"
@@ -201,7 +201,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["university_id"], name: "index_communication_extranet_posts_on_university_id"
   end
 
-  create_table "communication_extranets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_extranets", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.uuid "university_id", null: false
     t.string "host"
@@ -229,6 +229,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.text "home_sentence"
     t.text "sass"
     t.text "css"
+    t.boolean "allow_experiences_modification", default: true
     t.index ["about_type", "about_id"], name: "index_communication_extranets_on_about"
     t.index ["university_id"], name: "index_communication_extranets_on_university_id"
   end
@@ -311,7 +312,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["website_id"], name: "index_communication_website_connections_on_website_id"
   end
 
-  create_table "communication_website_git_files", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_git_files", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "previous_path"
     t.string "about_type", null: false
     t.uuid "about_id", null: false
@@ -323,7 +324,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["website_id"], name: "index_communication_website_git_files_on_website_id"
   end
 
-  create_table "communication_website_menu_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_menu_items", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "website_id", null: false
     t.uuid "menu_id", null: false
@@ -343,7 +344,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["website_id"], name: "index_communication_website_menu_items_on_website_id"
   end
 
-  create_table "communication_website_menus", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_menus", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "communication_website_id", null: false
     t.string "title"
@@ -359,7 +360,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["university_id"], name: "index_communication_website_menus_on_university_id"
   end
 
-  create_table "communication_website_pages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_pages", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "communication_website_id", null: false
     t.string "title"
@@ -373,10 +374,10 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.boolean "published", default: false
     t.string "featured_image_alt"
     t.text "text"
+    t.text "summary"
     t.string "breadcrumb_title"
     t.text "header_text"
     t.integer "kind"
-    t.text "summary"
     t.string "bodyclass"
     t.uuid "language_id", null: false
     t.text "featured_image_credit"
@@ -406,7 +407,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["website_id"], name: "index_communication_website_permalinks_on_website_id"
   end
 
-  create_table "communication_website_post_categories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_post_categories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "communication_website_id", null: false
     t.string "name"
@@ -433,7 +434,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["university_id"], name: "index_communication_website_post_categories_on_university_id"
   end
 
-  create_table "communication_website_posts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_website_posts", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "communication_website_id", null: false
     t.string "title"
@@ -460,7 +461,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["university_id"], name: "index_communication_website_posts_on_university_id"
   end
 
-  create_table "communication_websites", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "communication_websites", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.string "name"
     t.string "url"
@@ -531,7 +532,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table "education_academic_years", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "education_academic_years", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.integer "year"
     t.datetime "created_at", null: false
@@ -546,7 +547,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["university_person_id", "education_academic_year_id"], name: "index_person_academic_year"
   end
 
-  create_table "education_cohorts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "education_cohorts", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "program_id", null: false
     t.uuid "academic_year_id", null: false
@@ -567,7 +568,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["university_person_id", "education_cohort_id"], name: "index_person_cohort"
   end
 
-  create_table "education_diplomas", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "education_diplomas", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.string "short_name"
     t.integer "level", default: 0
@@ -582,7 +583,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["university_id"], name: "index_education_diplomas_on_university_id"
   end
 
-  create_table "education_programs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "education_programs", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.string "name"
     t.integer "capacity"
@@ -643,7 +644,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["education_program_id", "user_id"], name: "index_education_programs_users_on_program_id_and_user_id"
   end
 
-  create_table "education_schools", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "education_schools", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.string "name"
     t.string "address"
@@ -674,7 +675,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["university_id"], name: "index_emergency_messages_on_university_id", where: "(university_id IS NOT NULL)"
   end
 
-  create_table "imports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "imports", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.integer "number_of_lines"
     t.jsonb "processing_errors"
     t.integer "kind"
@@ -687,7 +688,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["user_id"], name: "index_imports_on_user_id"
   end
 
-  create_table "languages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "languages", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.string "iso_code"
     t.datetime "created_at", null: false
@@ -763,7 +764,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["university_id"], name: "index_research_journal_paper_kinds_on_university_id"
   end
 
-  create_table "research_journal_papers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_journal_papers", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "title"
     t.datetime "published_at", precision: nil
     t.uuid "university_id", null: false
@@ -801,7 +802,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["researcher_id"], name: "index_research_journal_papers_researchers_on_researcher_id"
   end
 
-  create_table "research_journal_volumes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_journal_volumes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "research_journal_id", null: false
     t.string "title"
@@ -822,7 +823,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["university_id"], name: "index_research_journal_volumes_on_university_id"
   end
 
-  create_table "research_journals", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_journals", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.string "title"
     t.text "meta_description"
@@ -833,7 +834,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["university_id"], name: "index_research_journals_on_university_id"
   end
 
-  create_table "research_laboratories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_laboratories", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.string "name"
     t.string "address"
@@ -852,7 +853,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["university_person_id", "research_laboratory_id"], name: "person_laboratory"
   end
 
-  create_table "research_laboratory_axes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_laboratory_axes", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "research_laboratory_id", null: false
     t.string "name"
@@ -866,7 +867,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["university_id"], name: "index_research_laboratory_axes_on_university_id"
   end
 
-  create_table "research_theses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "research_theses", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "research_laboratory_id", null: false
     t.uuid "author_id", null: false
@@ -884,7 +885,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["university_id"], name: "index_research_theses_on_university_id"
   end
 
-  create_table "universities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "universities", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.string "identifier"
     t.string "address"
@@ -931,7 +932,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["university_id"], name: "index_university_organization_categories_on_university_id"
   end
 
-  create_table "university_organizations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_organizations", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.string "name"
     t.string "long_name"
@@ -974,7 +975,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["organization_id"], name: "index_university_organizations_categories_on_organization_id"
   end
 
-  create_table "university_people", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_people", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "user_id"
     t.string "last_name"
@@ -1031,7 +1032,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["university_id"], name: "index_university_person_categories_on_university_id"
   end
 
-  create_table "university_person_experiences", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_person_experiences", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "person_id", null: false
     t.uuid "organization_id", null: false
@@ -1045,7 +1046,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["university_id"], name: "index_university_person_experiences_on_university_id"
   end
 
-  create_table "university_person_involvements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_person_involvements", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.uuid "person_id", null: false
     t.integer "kind"
@@ -1060,7 +1061,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["university_id"], name: "index_university_person_involvements_on_university_id"
   end
 
-  create_table "university_roles", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "university_roles", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.string "target_type"
     t.uuid "target_id"
@@ -1082,7 +1083,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_30_132952) do
     t.index ["user_id"], name: "index_user_favorites_on_user_id"
   end
 
-  create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "users", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "university_id", null: false
     t.string "first_name"
     t.string "last_name"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "codemirror": "5",
     "cropperjs": "^1.5.12",
     "jquery-cropper": "^1.0.1",
+    "leaflet": "^1.9.4",
     "notyf": "^3.10.0",
     "slug": "^5.1.0",
     "sortablejs": "^1.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -137,6 +137,11 @@ jquery-cropper@^1.0.1:
   resolved "https://registry.yarnpkg.com/jquery-cropper/-/jquery-cropper-1.0.1.tgz#6ba9faf1c2c86c0ac3c648d40554ba53673113cf"
   integrity sha512-KGlY8b0IJQi2Bxe3lqMKmd5Z2Ce4GrnDE5O8Iciza9xCzXISkL6EqX/jFHwnLL1H6Q4FGjoRguuv3lxezsbKJQ==
 
+leaflet@^1.9.4:
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.9.4.tgz#23fae724e282fa25745aff82ca4d394748db7d8d"
+  integrity sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==
+
 magic-string@^0.30.0:
   version "0.30.4"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.4.tgz#c2c683265fc18dda49b56fc7318d33ca0332c98c"


### PR DESCRIPTION
- Ajout de CSP explicites
- Passage de leaflet en package interne plutôt qu'un chargement par cdn
- début de simplication des styles inlines

A noter :
- ce sont des CSP souples. Comme on a des styles inline dynamiques (avec calculs liés à des itérations rails) on est un peu obligés de laisser ce style inline, et donc de ne pas forcer l'utilisation de nonce pour les styles (si on active les nonce on ne peut plus autoriser le unsafe_inline). Idem pour les scripts. L'utlisation de Vue.js oblige à autoriser le unsafe_eval.
- le CSP autorisent explicitement une version définie (v7) de Bugsnag. En cas de màj de Bugsnag il faudra changer cette directive (le numéro de version est en dur donc il faudra de toute façon le changer dans la vue, mais aussi dans le CSP)