### PR TITLE
Réparation du chemin des catégories d'événement

### DIFF
--- a/app/models/communication/website/agenda/category.rb
+++ b/app/models/communication/website/agenda/category.rb
@@ -16,6 +16,7 @@
 #  communication_website_id :uuid             not null, indexed
 #  language_id              :uuid             not null, indexed
 #  original_id              :uuid             indexed
+#  parent_id                :uuid             indexed
 #  university_id            :uuid             not null, indexed
 #
 # Indexes
@@ -23,11 +24,13 @@
 #  idx_communication_website_agenda_cats_on_website_id             (communication_website_id)
 #  index_communication_website_agenda_categories_on_language_id    (language_id)
 #  index_communication_website_agenda_categories_on_original_id    (original_id)
+#  index_communication_website_agenda_categories_on_parent_id      (parent_id)
 #  index_communication_website_agenda_categories_on_university_id  (university_id)
 #
 # Foreign Keys
 #
 #  fk_rails_1e1b9fbf33  (original_id => communication_website_agenda_categories.id)
+#  fk_rails_692dbf7723  (parent_id => communication_website_agenda_categories.id)
 #  fk_rails_6cb9a4b8a1  (university_id => universities.id)
 #  fk_rails_7b5ad84dda  (communication_website_id => communication_websites.id)
 #  fk_rails_b0ddee638d  (language_id => languages.id)
@@ -45,11 +48,16 @@ class Communication::Website::Agenda::Category < ApplicationRecord
   include WithTranslations
   include WithUniversity
 
+  belongs_to              :parent,
+                          class_name: 'Communication::Website::Agenda::Category',
+                          optional: true
   has_and_belongs_to_many :events,
                           class_name: 'Communication::Website::Agenda::Event',
                           join_table: :communication_website_agenda_events_categories,
                           foreign_key: :communication_website_agenda_category_id,
                           association_foreign_key: :communication_website_agenda_event_id
+
+  validates :name, presence: true
 
   def to_s
     "#{name}"

--- a/app/models/communication/website/post/category.rb
+++ b/app/models/communication/website/post/category.rb
@@ -54,7 +54,6 @@ class Communication::Website::Post::Category < ApplicationRecord
   include WithTree
   include WithUniversity
 
-  belongs_to              :university
   belongs_to              :parent,
                           class_name: 'Communication::Website::Post::Category',
                           optional: true

--- a/app/models/concerns/with_slug.rb
+++ b/app/models/concerns/with_slug.rb
@@ -34,6 +34,7 @@ module WithSlug
                 .exists?
     end
 
+    # FIXME `respond_to?(:parent)` sert à quoi ?
     def make_path
       return unless respond_to?(:path) && respond_to?(:parent)
       self.path = generated_path

--- a/db/migrate/20240117145932_add_parent_to_communication_website_agenda_categories.rb
+++ b/db/migrate/20240117145932_add_parent_to_communication_website_agenda_categories.rb
@@ -1,0 +1,5 @@
+class AddParentToCommunicationWebsiteAgendaCategories < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :communication_website_agenda_categories, :parent, foreign_key: {to_table: :communication_website_agenda_categories}, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_29_154550) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_17_145932) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -248,9 +248,11 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_29_154550) do
     t.uuid "university_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "parent_id"
     t.index ["communication_website_id"], name: "idx_communication_website_agenda_cats_on_website_id"
     t.index ["language_id"], name: "index_communication_website_agenda_categories_on_language_id"
     t.index ["original_id"], name: "index_communication_website_agenda_categories_on_original_id"
+    t.index ["parent_id"], name: "index_communication_website_agenda_categories_on_parent_id"
     t.index ["university_id"], name: "index_communication_website_agenda_categories_on_university_id"
   end
 
@@ -1157,6 +1159,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_29_154550) do
   add_foreign_key "communication_extranet_posts", "university_people", column: "author_id"
   add_foreign_key "communication_extranets", "universities"
   add_foreign_key "communication_website_agenda_categories", "communication_website_agenda_categories", column: "original_id"
+  add_foreign_key "communication_website_agenda_categories", "communication_website_agenda_categories", column: "parent_id"
   add_foreign_key "communication_website_agenda_categories", "communication_websites"
   add_foreign_key "communication_website_agenda_categories", "languages"
   add_foreign_key "communication_website_agenda_categories", "universities"

--- a/test/fixtures/communication/website/agenda/categories.yml
+++ b/test/fixtures/communication/website/agenda/categories.yml
@@ -16,6 +16,7 @@
 #  communication_website_id :uuid             not null, indexed
 #  language_id              :uuid             not null, indexed
 #  original_id              :uuid             indexed
+#  parent_id                :uuid             indexed
 #  university_id            :uuid             not null, indexed
 #
 # Indexes
@@ -23,11 +24,13 @@
 #  idx_communication_website_agenda_cats_on_website_id             (communication_website_id)
 #  index_communication_website_agenda_categories_on_language_id    (language_id)
 #  index_communication_website_agenda_categories_on_original_id    (original_id)
+#  index_communication_website_agenda_categories_on_parent_id      (parent_id)
 #  index_communication_website_agenda_categories_on_university_id  (university_id)
 #
 # Foreign Keys
 #
 #  fk_rails_1e1b9fbf33  (original_id => communication_website_agenda_categories.id)
+#  fk_rails_692dbf7723  (parent_id => communication_website_agenda_categories.id)
 #  fk_rails_6cb9a4b8a1  (university_id => universities.id)
 #  fk_rails_7b5ad84dda  (communication_website_id => communication_websites.id)
 #  fk_rails_b0ddee638d  (language_id => languages.id)

--- a/test/models/communication/website/agenda/category_test.rb
+++ b/test/models/communication/website/agenda/category_test.rb
@@ -16,6 +16,7 @@
 #  communication_website_id :uuid             not null, indexed
 #  language_id              :uuid             not null, indexed
 #  original_id              :uuid             indexed
+#  parent_id                :uuid             indexed
 #  university_id            :uuid             not null, indexed
 #
 # Indexes
@@ -23,11 +24,13 @@
 #  idx_communication_website_agenda_cats_on_website_id             (communication_website_id)
 #  index_communication_website_agenda_categories_on_language_id    (language_id)
 #  index_communication_website_agenda_categories_on_original_id    (original_id)
+#  index_communication_website_agenda_categories_on_parent_id      (parent_id)
 #  index_communication_website_agenda_categories_on_university_id  (university_id)
 #
 # Foreign Keys
 #
 #  fk_rails_1e1b9fbf33  (original_id => communication_website_agenda_categories.id)
+#  fk_rails_692dbf7723  (parent_id => communication_website_agenda_categories.id)
 #  fk_rails_6cb9a4b8a1  (university_id => universities.id)
 #  fk_rails_7b5ad84dda  (communication_website_id => communication_websites.id)
 #  fk_rails_b0ddee638d  (language_id => languages.id)


### PR DESCRIPTION
Fix #1544

Il y a un couplage très étrange entre `slug` et `parent`, qui date d'il y a deux ans. 
Je soupçonne que ce soit obsolète, mais je n'en suis pas certain.