### PR TITLE
Réparation des guillemets

### DIFF
--- a/app/views/admin/administration/locations/static.html.erb
+++ b/app/views/admin/administration/locations/static.html.erb
@@ -1,7 +1,6 @@
 ---
-title: >
-  <%= prepare_text_for_static @about.name %>
-<%= render 'admin/application/static/permalink' if @website %>
+<%= render 'admin/application/static/title' %>
+<%= render 'admin/application/static/permalink' %>
 <%= render 'admin/application/static/design', full_width: true, toc_offcanvas: true %>
 <% if @website %>
 <%= render 'admin/application/static/breadcrumbs', 

--- a/app/views/admin/application/static/_breadcrumbs.html.erb
+++ b/app/views/admin/application/static/_breadcrumbs.html.erb
@@ -1,6 +1,7 @@
 breadcrumbs:
 <% pages.each do |page| %>
-  - title: "<%= page.best_title %>"
+  - title: >-
+      <%= page.best_title %>
     path: "<%= page.path %>"
 <% end %>
   - title: >-

--- a/app/views/admin/application/static/_permalink.html.erb
+++ b/app/views/admin/application/static/_permalink.html.erb
@@ -1,3 +1,4 @@
+<% if @website %>
 url: "<%= @about.current_permalink_in_website(@website)&.path %>"
 <% if @about.respond_to?(:slug) && @about.slug.present? %>
 <% forced_slug ||= nil %>
@@ -10,5 +11,6 @@ if previous_permalinks.any?
 aliases:
 <% previous_permalinks.each do |permalink| %>
   - <%= permalink.path %>
+<% end %>
 <% end %>
 <% end %>

--- a/app/views/admin/application/static/_title.html.erb
+++ b/app/views/admin/application/static/_title.html.erb
@@ -1,0 +1,2 @@
+title: >-
+  <%= prepare_text_for_static @about.to_s %>

--- a/app/views/admin/communication/blocks/headings/_static.html.erb
+++ b/app/views/admin/communication/blocks/headings/_static.html.erb
@@ -1,5 +1,6 @@
   - kind: heading
-    title: "<%= prepare_text_for_static heading.title %>"
+    title: >-
+      <%= prepare_text_for_static heading.title %>
     position: <%= heading.position %>
     rank: <%= heading.level %>
 <% heading.blocks.published.ordered.each do |block| %>

--- a/app/views/admin/communication/blocks/templates/video/_static.html.erb
+++ b/app/views/admin/communication/blocks/templates/video/_static.html.erb
@@ -6,7 +6,8 @@
       video: 
         platform: "<%= block.template.video_platform %>"
         identifier: "<%= block.template.video_identifier %>"
-        title: "<%= block.template.video_iframe_title %>"
+        title: >-
+          <%= block.template.video_iframe_title %>
         poster: >-
           <%= block.template.video_poster %>
         embed: >-

--- a/app/views/admin/communication/websites/agenda/categories/static.html.erb
+++ b/app/views/admin/communication/websites/agenda/categories/static.html.erb
@@ -1,5 +1,5 @@
 ---
-title: "<%= @about.name %>"
+<%= render 'admin/application/static/title' %>
 <%= render 'admin/application/static/permalink' %>
 <%= render 'admin/application/static/design', full_width: true, toc_offcanvas: true %>
 <%= render 'admin/application/static/breadcrumbs',

--- a/app/views/admin/communication/websites/agenda/events/static.html.erb
+++ b/app/views/admin/communication/websites/agenda/events/static.html.erb
@@ -1,6 +1,7 @@
 ---
-title: "<%= prepare_text_for_static @about.title %>"
-subtitle: "<%= prepare_text_for_static @about.subtitle %>"
+<%= render 'admin/application/static/title' %>
+subtitle: >-
+  <%= prepare_text_for_static @about.subtitle %>
 <%= render 'admin/communication/websites/agenda/events/dates_static', event: @about %>
 <%= render 'admin/application/static/breadcrumbs',
             pages: @website.special_page(Communication::Website::Page::CommunicationAgenda).ancestors_and_self,

--- a/app/views/admin/communication/websites/pages/static.html.erb
+++ b/app/views/admin/communication/websites/pages/static.html.erb
@@ -1,6 +1,7 @@
 ---
-title: "<%= prepare_text_for_static @about.title %>"
-breadcrumb_title: "<%= prepare_text_for_static @about.best_title %>"
+<%= render 'admin/application/static/title' %>
+breadcrumb_title: >-
+  <%= prepare_text_for_static @about.best_title %>
 <%= render 'admin/application/static/breadcrumbs', 
             pages: @about.ancestors,
             current_title: @about.best_title %>

--- a/app/views/admin/communication/websites/posts/categories/static.html.erb
+++ b/app/views/admin/communication/websites/posts/categories/static.html.erb
@@ -1,5 +1,5 @@
 ---
-title: "<%= prepare_text_for_static @about.name %>"
+<%= render 'admin/application/static/title' %>
 <%= render 'admin/application/static/permalink', forced_slug: @about.slug_with_ancestors_slugs %>
 <%= render 'admin/application/static/design', full_width: true, toc_offcanvas: true %>
 <%= render 'admin/application/static/breadcrumbs',

--- a/app/views/admin/communication/websites/posts/static.html.erb
+++ b/app/views/admin/communication/websites/posts/static.html.erb
@@ -1,5 +1,5 @@
 ---
-title: "<%= prepare_text_for_static @about.title %>"
+<%= render 'admin/application/static/title' %>
 date: "<%= @about.published_at&.iso8601 %>"
 <%= render 'admin/application/static/breadcrumbs',
             pages: @website.special_page(Communication::Website::Page::CommunicationPost).ancestors_and_self,

--- a/app/views/admin/communication/websites/static.html.erb
+++ b/app/views/admin/communication/websites/static.html.erb
@@ -1,5 +1,4 @@
-title: >
-  <%= @about.to_s %>
+<%= render 'admin/application/static/title' %>
 default:
 <% if @website.default_image.attached? %>
   image:

--- a/app/views/admin/education/diplomas/static.html.erb
+++ b/app/views/admin/education/diplomas/static.html.erb
@@ -1,5 +1,5 @@
 ---
-title: "<%= prepare_text_for_static @about.name %>"
+<%= render 'admin/application/static/title' %>
 <%= render 'admin/application/static/permalink' if @website %>
 <%= render 'admin/application/static/design', full_width: true, toc_offcanvas: true %>
 <%= render 'admin/application/static/breadcrumbs',

--- a/app/views/admin/education/programs/static.html.erb
+++ b/app/views/admin/education/programs/static.html.erb
@@ -7,7 +7,7 @@ administrator_involvements = @about.involvements_through_roles
                                    .includes(:person)
                                    .ordered_by_name
 %>
-title: "<%= prepare_text_for_static @about.name %>"
+<%= render 'admin/application/static/title' %>
 <%= render 'admin/application/static/permalink' %>
 <%= render 'admin/application/static/design', full_width: false, toc_offcanvas: true, toc_present: true %>
 <%= render 'admin/application/static/breadcrumbs',

--- a/app/views/admin/research/journals/papers/kinds/static.html.erb
+++ b/app/views/admin/research/journals/papers/kinds/static.html.erb
@@ -1,4 +1,4 @@
 ---
-title: "<%= prepare_text_for_static @about.title %>"
+<%= render 'admin/application/static/title' %>
 slug: "<%= @about.slug %>"
 ---

--- a/app/views/admin/research/journals/papers/static.html.erb
+++ b/app/views/admin/research/journals/papers/static.html.erb
@@ -1,5 +1,5 @@
 ---
-title: "<%= prepare_text_for_static @about.title %>"
+<%= render 'admin/application/static/title' %>
 <%= render 'admin/application/static/design', full_width: false, toc_offcanvas: false, toc_present: true %>
 <%= render 'admin/application/static/permalink' %>
 <%= render 'admin/application/static/design', full_width: false, toc_offcanvas: false %>

--- a/app/views/admin/research/journals/static.html.erb
+++ b/app/views/admin/research/journals/static.html.erb
@@ -1,7 +1,6 @@
 ---
-title: >
-  <%= @about.title %>
-issn: >
+<%= render 'admin/application/static/title' %>
+issn: >-
   <%= @about.issn %>
 <%= render 'admin/application/meta_description/static' %>
 <%= render 'admin/application/summary/static' %>

--- a/app/views/admin/research/journals/volumes/static.html.erb
+++ b/app/views/admin/research/journals/volumes/static.html.erb
@@ -1,5 +1,5 @@
 ---
-title: "<%= prepare_text_for_static @about.title %>"
+<%= render 'admin/application/static/title' %>
 <%= render 'admin/application/static/design', full_width: true, toc_offcanvas: false, toc_present: false %>
 <%= render 'admin/application/static/permalink' %>
 <%= render 'admin/application/static/design', full_width: true, toc_offcanvas: false, toc_present: false %>

--- a/app/views/admin/research/publications/static.html.erb
+++ b/app/views/admin/research/publications/static.html.erb
@@ -3,8 +3,7 @@ special_page = @website.special_page(Communication::Website::Page::ResearchPubli
 pages = special_page.ancestors_and_self if special_page
 %>
 ---
-title: >-
-  <%= @about.title %>
+<%= render 'admin/application/static/title' %>
 date: "<%= @about.publication_date&.iso8601 %>"
 <%= render 'admin/application/static/breadcrumbs',
             pages: pages,

--- a/app/views/admin/university/organizations/static.html.erb
+++ b/app/views/admin/university/organizations/static.html.erb
@@ -1,5 +1,5 @@
 ---
-title: "<%= prepare_text_for_static @about.to_s %>"
+<%= render 'admin/application/static/title' %>
 <%= render 'admin/application/static/breadcrumbs', 
             pages: @website.special_page(Communication::Website::Page::Organization).ancestors_and_self,
             current_title: @about.to_s %>

--- a/app/views/admin/university/people/administrators/static.html.erb
+++ b/app/views/admin/university/people/administrators/static.html.erb
@@ -1,5 +1,5 @@
 ---
-title: >
+title: >-
   Responsabilités de <%= @about.to_s %>
 breadcrumbs:
 <% @website.special_page(Communication::Website::Page::Person).ancestors_and_self.each do |page| %>

--- a/app/views/admin/university/people/authors/static.html.erb
+++ b/app/views/admin/university/people/authors/static.html.erb
@@ -1,5 +1,5 @@
 ---
-title: >
+title: >-
   Actualités de <%= @about.to_s %>
 breadcrumbs:
 <% @website.special_page(Communication::Website::Page::Person).ancestors_and_self.each do |page| %>

--- a/app/views/admin/university/people/researchers/static.html.erb
+++ b/app/views/admin/university/people/researchers/static.html.erb
@@ -1,5 +1,5 @@
 ---
-title: >
+title: >-
   Publications de <%= @about.to_s %>
 breadcrumbs:
 <% @website.special_page(Communication::Website::Page::Person).ancestors_and_self.each do |page| %>

--- a/app/views/admin/university/people/static.html.erb
+++ b/app/views/admin/university/people/static.html.erb
@@ -1,6 +1,5 @@
 ---
-title: >-
-  <%= @about.to_s %>
+<%= render 'admin/application/static/title' %>
 linkTitle: >-
   <%= @about.to_s_alphabetical %>
 <%= render 'admin/application/static/breadcrumbs',
@@ -11,15 +10,15 @@ linkTitle: >-
 <%= render 'admin/application/summary/static' %>
 <%= render 'admin/application/static/design', full_width: true, toc_offcanvas: true %>
 <%= render 'admin/application/i18n/static' %>
-first_name: >
+first_name: >-
   <%= @about.first_name %>
-last_name: >
+last_name: >-
   <%= @about.last_name %>
-phone: >
+phone: >-
   <%= @about.phone_mobile %>
-email: >
+email: >-
   <%= @about.email %>
-twitter: >
+twitter: >-
   <%= @about.twitter %>
 linkedin: >-
   <%= @about.linkedin %>
@@ -64,9 +63,9 @@ teachings:
   - description: >
       <%= involvement.description %>
     program:
-      title: >
+      title: >-
         <%= target.to_s %>
-      url: >
+      url: >-
         <%= target.current_permalink_in_website(@website)&.path %>
 <% end %>
 <% end %>
@@ -77,9 +76,9 @@ administrative_missions:
   - description: >
       <%= role.to_s %>
     target:
-      title: >
+      title: >-
         <%= target.to_s %>
-      url: >
+      url: >-
         <%= target.current_permalink_in_website(@website)&.path if target.respond_to? :current_permalink_in_website %>
 <% end %>
 <% end %>

--- a/app/views/admin/university/people/teachers/static.html.erb
+++ b/app/views/admin/university/people/teachers/static.html.erb
@@ -1,5 +1,5 @@
 ---
-title: >
+title: >-
   Enseignements de <%= @about.to_s %>
 breadcrumbs:
 <% @website.special_page(Communication::Website::Page::Person).ancestors_and_self.each do |page| %>


### PR DESCRIPTION
Contexte : depuis la màj liée à orthotypo les titres ne sont plus encodés de la même manière.
L'ajout de guillements dans un titre fait crasher la compilation