### PR TITLE
redirect to "/" instead of root_path to be clear and handle activestorage

### DIFF
--- a/app/controllers/application_controller/with_errors.rb
+++ b/app/controllers/application_controller/with_errors.rb
@@ -27,7 +27,7 @@ module ApplicationController::WithErrors
     end
 
     def handle_unverified_request
-      redirect_back(fallback_location: root_path, alert: t('inactivity_alert'))
+      redirect_back(fallback_location: '/', alert: t('inactivity_alert'))
     end
 
     def render_not_found


### PR DESCRIPTION
C'était ça ou override dans ActiveStorage::BaseController mais je trouve ça + clean comme ça